### PR TITLE
Determine TensorFlow job names in user configuration at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,3 +137,7 @@ CLI configurations have highest priority, so we will get 2 ps instances and 2 wo
     Why?
     
     Try adding the path to your libjvm.so shared library to your LD_LIBRARY_PATH environment variable for your workers. See above for an example.
+
+2. How do I configure arbitrary TensorFlow job types?
+
+    Please see the [wiki](https://github.com/linkedin/TonY/wiki/TonY-Configurations#task-configuration) on TensorFlow task configuration for details.

--- a/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
@@ -290,38 +290,14 @@ public class TonyClient {
 
     hdfsClasspath = cliParser.getOptionValue("hdfs_classpath");
 
-    String psMemoryString = tonyConf.get(TonyConfigurationKeys.PS_MEMORY,
-        TonyConfigurationKeys.DEFAULT_PS_MEMORY);
-    long psMemory = Long.parseLong(Utils.parseMemoryString(psMemoryString));
-    int psVCores = tonyConf.getInt(TonyConfigurationKeys.PS_VCORES,
-        TonyConfigurationKeys.DEFAULT_PS_VCORES);
-    String workerMemoryString = tonyConf.get(TonyConfigurationKeys.WORKER_MEMORY,
-        TonyConfigurationKeys.DEFAULT_WORKER_MEMORY);
-    long workerMemory = Long.parseLong(Utils.parseMemoryString(workerMemoryString));
-    int workerVCores = tonyConf.getInt(TonyConfigurationKeys.WORKER_VCORES,
-        TonyConfigurationKeys.DEFAULT_WORKER_VCORES);
-
-    int numPs = tonyConf.getInt(TonyConfigurationKeys.PS_INSTANCES,
-        TonyConfigurationKeys.DEFAULT_PS_INSTANCES);
-    int numWorkers = tonyConf.getInt(TonyConfigurationKeys.WORKER_INSTANCES,
-        TonyConfigurationKeys.DEFAULT_WORKER_INSTANCES);
-
-    if (psMemory < 0 || psVCores < 0 || workerMemory < 0 || workerVCores < 0) {
-      throw new IllegalArgumentException("Invalid container memory/vcores specified,"
-                                         + " exiting."
-                                         + " Specified psMemory=" + psMemory
-                                         + ", psVCores=" + psVCores
-                                         + ", workerMemory=" + workerMemory
-                                         + ", workerVCores=" + workerVCores);
-    }
-
+    int numWorkers = tonyConf.getInt(TonyConfigurationKeys.getInstancesKey(Constants.WORKER_JOB_NAME),
+        TonyConfigurationKeys.getDefaultInstances(Constants.WORKER_JOB_NAME));
     boolean singleNode = tonyConf.getBoolean(TonyConfigurationKeys.IS_SINGLE_NODE,
         TonyConfigurationKeys.DEFAULT_IS_SINGLE_NODE);
     if (!singleNode) {
-      if (numPs < 1 || numWorkers < 1) {
+      if (numWorkers < 1) {
         throw new IllegalArgumentException(
-            "Cannot request non-positive ps or worker instances. requested numPs=" + numPs
-                + ", requested numWorkers=" + numWorkers);
+            "Cannot request non-positive worker instances. Requested numWorkers=" + numWorkers);
       }
       if (amGpus > 0) {
         LOG.warn("It seems you reserved " + amGpus + " GPUs in application master (driver, which doesn't perform training) during distributed training.");

--- a/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
@@ -70,35 +70,42 @@ public class TonyConfigurationKeys {
   public static final String AM_GPUS = AM_PREFIX + "gpus";
   public static final int DEFAULT_AM_GPUS = 0;
 
-  // PS configurations
-  public static final String PS_PREFIX = TONY_PREFIX + "ps.";
+  // Keys/default values for configurable TensorFlow job names
+  public static final String INSTANCES_REGEX = "tony\\.([a-z]+)\\.instances";
+  public static final String DEFAULT_MEMORY = "2g";
+  public static final int DEFAULT_VCORES = 1;
+  public static final int DEFAULT_GPUS = 0;
 
-  public static final String PS_MEMORY = PS_PREFIX + "memory";
-  public static final String DEFAULT_PS_MEMORY = "2g";
+  public static String getInstancesKey(String jobName) {
+    return String.format(TONY_PREFIX + "%s.instances", jobName);
+  }
 
-  public static final String PS_VCORES = PS_PREFIX + "vcores";
-  public static final int DEFAULT_PS_VCORES = 1;
+  public static int getDefaultInstances(String jobName) {
+    switch (jobName) {
+      case Constants.PS_JOB_NAME:
+      case Constants.WORKER_JOB_NAME:
+        return 1;
+      default:
+        return 0;
+    }
+  }
+  public static String getMemoryKey(String jobName) {
+    return String.format(TONY_PREFIX + "%s.memory", jobName);
+  }
 
-  public static final String PS_INSTANCES = PS_PREFIX + "instances";
-  public static final int DEFAULT_PS_INSTANCES = 1;
+  public static String getVCoresKey(String jobName) {
+    return String.format(TONY_PREFIX + "%s.vcores", jobName);
+  }
+
+  public static String getGPUsKey(String jobName) {
+    return String.format(TONY_PREFIX + "%s.gpus", jobName);
+  }
 
   // Worker configurations
   public static final String WORKER_PREFIX = TONY_PREFIX + "worker.";
 
   public static final String WORKER_TIMEOUT = WORKER_PREFIX + "timeout";
   public static final int DEFAULT_WORKER_TIMEOUT = 0;
-
-  public static final String WORKER_MEMORY = WORKER_PREFIX + "memory";
-  public static final String DEFAULT_WORKER_MEMORY = "2g";
-
-  public static final String WORKER_VCORES = WORKER_PREFIX  + "vcores";
-  public static final int DEFAULT_WORKER_VCORES = 1;
-
-  public static final String WORKER_GPUS = WORKER_PREFIX + "gpus";
-  public static final int DEFAULT_WORKER_GPUS = 0;
-
-  public static final String WORKER_INSTANCES = WORKER_PREFIX + "instances";
-  public static final int DEFAULT_WORKER_INSTANCES = 1;
 
   // Local testing configurations
   public static final String SECURITY_ENABLED = TONY_APPLICATION_PREFIX + "security.enabled";

--- a/tony-core/src/main/java/com/linkedin/tony/tensorflow/TensorFlowContainerRequest.java
+++ b/tony-core/src/main/java/com/linkedin/tony/tensorflow/TensorFlowContainerRequest.java
@@ -4,40 +4,42 @@
  */
 package com.linkedin.tony.tensorflow;
 
-import org.apache.hadoop.yarn.api.records.Resource;
-import org.apache.hadoop.yarn.api.records.ResourceInformation;
-import org.apache.hadoop.yarn.exceptions.ResourceNotFoundException;
-
 
 public class TensorFlowContainerRequest {
-  private int virtualCores;
+  private int numInstances;
   private long memory;
+  private int vCores;
   private int priority;
   private int gpu;
   private String jobName;
 
-  public TensorFlowContainerRequest(String jobName, int virtualCores, long memory, int gpu, int priority) {
-    this.virtualCores = virtualCores;
+  public TensorFlowContainerRequest(String jobName, int numInstances, long memory, int vCores, int gpu, int priority) {
+    this.numInstances = numInstances;
     this.memory = memory;
+    this.vCores = vCores;
     this.priority = priority;
     this.gpu = gpu;
     this.jobName = jobName;
   }
 
   public TensorFlowContainerRequest(TensorFlowContainerRequest that) {
-    this.virtualCores = that.virtualCores;
     this.memory = that.memory;
+    this.vCores = that.vCores;
     this.gpu = that.gpu;
     this.priority = that.priority;
     this.jobName = that.jobName;
   }
 
-  public int getVirtualCores() {
-    return virtualCores;
+  public int getNumInstances() {
+    return numInstances;
   }
 
   public long getMemory() {
     return memory;
+  }
+
+  public int getVCores() {
+    return vCores;
   }
 
   public int getGPU() {

--- a/tony-core/src/test/java/com/linkedin/tony/TestTonyConfigurationFields.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestTonyConfigurationFields.java
@@ -29,6 +29,17 @@ public class TestTonyConfigurationFields extends TestConfigurationFieldsBase {
     // Set error modes
     errorIfMissingConfigProps = true;
     errorIfMissingXmlProps = true;
+
+    // We don't explicitly declare constants for these, since the configured TensorFlow job names
+    // are determined at runtime. But we still need default values for them in tony-default.xml.
+    // So ignore the fact that they exist in tony-default.xml and not in TonyConfigurationKeys.
+    xmlPropsToSkipCompare.add(TonyConfigurationKeys.getInstancesKey(Constants.PS_JOB_NAME));
+    xmlPropsToSkipCompare.add(TonyConfigurationKeys.getMemoryKey(Constants.PS_JOB_NAME));
+    xmlPropsToSkipCompare.add(TonyConfigurationKeys.getVCoresKey(Constants.PS_JOB_NAME));
+    xmlPropsToSkipCompare.add(TonyConfigurationKeys.getInstancesKey(Constants.WORKER_JOB_NAME));
+    xmlPropsToSkipCompare.add(TonyConfigurationKeys.getMemoryKey(Constants.WORKER_JOB_NAME));
+    xmlPropsToSkipCompare.add(TonyConfigurationKeys.getVCoresKey(Constants.WORKER_JOB_NAME));
+    xmlPropsToSkipCompare.add(TonyConfigurationKeys.getGPUsKey(Constants.WORKER_JOB_NAME));
   }
 
   @BeforeTest

--- a/tony-core/src/test/java/com/linkedin/tony/TestTonyE2E.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestTonyE2E.java
@@ -94,7 +94,7 @@ public class TestTonyE2E {
     conf.setBoolean(TonyConfigurationKeys.SECURITY_ENABLED, false);
     conf.set(TonyConfigurationKeys.HDFS_CONF_LOCATION, hdfsConf);
     conf.set(TonyConfigurationKeys.YARN_CONF_LOCATION, yarnConf);
-    conf.setInt(TonyConfigurationKeys.WORKER_INSTANCES, 2);
+    conf.setInt(TonyConfigurationKeys.getInstancesKey("worker"), 2);
     int exitCode = TonyClient.start(new String[]{
         "--src_dir", "tony-core/src/test/resources/",
         "--executes", "tony-core/src/test/resources/exit_0_check_env.py",
@@ -185,8 +185,8 @@ public class TestTonyE2E {
     conf.setBoolean(TonyConfigurationKeys.SECURITY_ENABLED, false);
     conf.set(TonyConfigurationKeys.HDFS_CONF_LOCATION, hdfsConf);
     conf.set(TonyConfigurationKeys.YARN_CONF_LOCATION, yarnConf);
-    conf.setInt(TonyConfigurationKeys.PS_INSTANCES, 2);
-    conf.setInt(TonyConfigurationKeys.WORKER_INSTANCES, 2);
+    conf.setInt(TonyConfigurationKeys.getInstancesKey("ps"), 2);
+    conf.setInt(TonyConfigurationKeys.getInstancesKey("worker"), 2);
     conf.setInt(TonyConfigurationKeys.TASK_REGISTRATION_TIMEOUT_SEC, 20);
     conf.setInt(TonyConfigurationKeys.TASK_REGISTRATION_RETRY_COUNT, 1);
     int exitCode = TonyClient.start(new String[]{

--- a/tony-core/src/test/java/com/linkedin/tony/TestUtils.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestUtils.java
@@ -8,6 +8,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Map;
+
+import com.linkedin.tony.tensorflow.TensorFlowContainerRequest;
+import org.apache.hadoop.conf.Configuration;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
@@ -40,6 +44,30 @@ public class TestUtils {
     } catch (IOException e) {
       fail(e.toString());
     }
+  }
 
+  @Test
+  public void testParseContainerRequests() {
+    Configuration conf = new Configuration();
+    conf.addResource("tony-default.xml");
+    conf.setInt("tony.worker.instances", 3);
+    conf.setInt("tony.evaluator.instances", 1);
+    conf.set("tony.ps.memory", "3g");
+    conf.setInt("tony.worker.gpus", 1);
+    conf.setInt("tony.evaluator.vcores", 2);
+    conf.setInt("tony.chief.gpus", 1);
+
+    Map<String, TensorFlowContainerRequest> requests = Utils.parseContainerRequests(conf);
+    // PS and worker should use default 1 instance
+    assertEquals(1, requests.get("ps").getNumInstances());
+    assertEquals(3, requests.get("worker").getNumInstances());
+    assertEquals(1, requests.get("evaluator").getNumInstances());
+    assertEquals(3072, requests.get("ps").getMemory());
+    assertEquals(1, requests.get("worker").getGPU());
+    assertEquals(2, requests.get("evaluator").getVCores());
+    // Check default value.
+    assertEquals(2048, requests.get("worker").getMemory());
+    // Check job does not exist if no instances are configured.
+    assertFalse(requests.containsKey("chief"));
   }
 }


### PR DESCRIPTION
Currently configurations such as tony.worker.instances are hardcoded to use job names like "worker".

Instead, we want to resolve these configured job names at runtime, so if the user specifies "tony.chief.instances", it will handle this as another TensorFlow job type (i.e. include it in the cluster spec, parse out tony.chief.memory, tony.chief.gpus, etc. if included in the conf). This way arbitrary TensorFlow job names can be requested.