### PR TITLE
couldn't get hdfs name service when start tony-cli driver

### DIFF
--- a/tony-cli/src/main/java/com/linkedin/tony/cli/ClusterSubmitter.java
+++ b/tony-cli/src/main/java/com/linkedin/tony/cli/ClusterSubmitter.java
@@ -39,6 +39,7 @@ public class ClusterSubmitter {
     String jarLocation = new File(ClusterSubmitter.class.getProtectionDomain().getCodeSource().getLocation().toURI()).getPath();
     Configuration hdfsConf = new Configuration();
     hdfsConf.addResource(new Path(System.getenv(HADOOP_CONF_DIR) + File.separatorChar + CORE_SITE_CONF));
+    hdfsConf.addResource(new Path(System.getenv(HADOOP_CONF_DIR) + File.separatorChar + HDFS_SITE_CONF));
     LOG.info(hdfsConf);
     int exitCode;
     try (FileSystem fs = FileSystem.get(hdfsConf)) {


### PR DESCRIPTION
when I started the ClusterSubmitter,  it failed immediately. 

Exception in thread "main" java.lang.IllegalArgumentException: java.net.UnknownHostException: my-cluster
	at org.apache.hadoop.security.SecurityUtil.buildTokenService(SecurityUtil.java:375)
	at org.apache.hadoop.hdfs.NameNodeProxies.createNonHAProxy(NameNodeProxies.java:320)
	at org.apache.hadoop.hdfs.NameNodeProxies.createProxy(NameNodeProxies.java:176)
	at org.apache.hadoop.hdfs.DFSClient.<init>(DFSClient.java:668)
	at org.apache.hadoop.hdfs.DFSClient.<init>(DFSClient.java:604)
	at org.apache.hadoop.hdfs.DistributedFileSystem.initialize(DistributedFileSystem.java:148)
	at org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:2598)
	at org.apache.hadoop.fs.FileSystem.access$200(FileSystem.java:91)
	at org.apache.hadoop.fs.FileSystem$Cache.getInternal(FileSystem.java:2632)
	at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:2614)
	at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:370)
	at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:169)
	at com.linkedin.tony.cli.ClusterSubmitter.main(ClusterSubmitter.java:45)
Caused by: java.net.UnknownHostException: my-cluster

The cause is that "my-cluster" is a hdfs nameservice name, it relies on hdfs-site.xml. 
It is also used when hadoop HA is configured.
<property>
        <name>dfs.nameservices</name>
        <value>my-cluster</value>
</property>

so hdfs-site.xml should be added to resource as well. 