### PR TITLE
Enable TonY to localize a list of resources to local container

### DIFF
--- a/tony-cli/src/main/java/com/linkedin/tony/cli/ClusterSubmitter.java
+++ b/tony-cli/src/main/java/com/linkedin/tony/cli/ClusterSubmitter.java
@@ -8,7 +8,9 @@ package com.linkedin.tony.cli;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 
 import com.linkedin.tony.TonyClient;
@@ -51,10 +53,11 @@ public class ClusterSubmitter {
       fs.mkdirs(cachedLibPath);
       fs.copyFromLocalFile(new Path(jarLocation), cachedLibPath);
 
-      String[] updatedArgs = Arrays.copyOf(args, args.length + 2);
-      updatedArgs[args.length] = "--hdfs_classpath";
-      updatedArgs[args.length + 1] = cachedLibPath.toString();
-      exitCode = TonyClient.start(updatedArgs);
+      // Insert --hdfs_classpath at the beginning to avoid confusion when user pass in wrong arguments.
+      List<String> updatedArgs = new ArrayList<>(Arrays.asList(args));
+      updatedArgs.add(0, cachedLibPath.toString());
+      updatedArgs.add(0, "--hdfs_classpath");
+      exitCode = TonyClient.start((String[])updatedArgs.toArray());
     } catch (IOException e) {
       LOG.fatal("Failed to create FileSystem: ", e);
       exitCode = -1;

--- a/tony-cli/src/main/java/com/linkedin/tony/cli/ClusterSubmitter.java
+++ b/tony-cli/src/main/java/com/linkedin/tony/cli/ClusterSubmitter.java
@@ -8,8 +8,8 @@ package com.linkedin.tony.cli;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
 
@@ -54,7 +54,7 @@ public class ClusterSubmitter {
       fs.copyFromLocalFile(new Path(jarLocation), cachedLibPath);
 
       // Insert --hdfs_classpath at the beginning to avoid confusion when user pass in wrong arguments.
-      List<String> updatedArgs = new ArrayList<>(Arrays.asList(args));
+      List<String> updatedArgs = new LinkedList<>(Arrays.asList(args));
       updatedArgs.add(0, cachedLibPath.toString());
       updatedArgs.add(0, "--hdfs_classpath");
       exitCode = TonyClient.start((String[])updatedArgs.toArray());

--- a/tony-core/src/main/java/com/linkedin/tony/Constants.java
+++ b/tony-core/src/main/java/com/linkedin/tony/Constants.java
@@ -53,6 +53,7 @@ public class Constants {
   public static final String CORE_SITE_CONF = YarnConfiguration.CORE_SITE_CONFIGURATION_FILE;
   public static final String HADOOP_CONF_DIR = ApplicationConstants.Environment.HADOOP_CONF_DIR.key();
 
+  public static final String AM_NAME = "am";
   public static final String WORKER_JOB_NAME = "worker";
   public static final String PS_JOB_NAME = "ps";
   public static final String NOTEBOOK_JOB_NAME = "notebook";

--- a/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
+import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -23,6 +24,7 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.hadoop.yarn.api.records.ContainerId;
@@ -59,6 +61,7 @@ public class TaskExecutor {
   private String taskId;
   private int numTasks;
   private Configuration yarnConf = new Configuration();
+  private Configuration hdfsConf = new Configuration();
   private ApplicationRpcClient proxy;
   private Map<String, String> shellEnv = new HashMap<>();
   private int hbInterval;
@@ -74,91 +77,89 @@ public class TaskExecutor {
     this.tbPort = this.tbSocket.getLocalPort();
     this.gatewayServerSocket = new ServerSocket(0);
     this.gatewayServerPort = this.gatewayServerSocket.getLocalPort();
-    this.framework = MLFramework.valueOf(tonyConf.get(TonyConfigurationKeys.FRAMEWORK_NAME,
-        TonyConfigurationKeys.DEFAULT_FRAMEWORK_NAME).toUpperCase());
+    this.framework = MLFramework.valueOf(
+        tonyConf.get(TonyConfigurationKeys.FRAMEWORK_NAME, TonyConfigurationKeys.DEFAULT_FRAMEWORK_NAME).toUpperCase());
 
     LOG.info("Reserved rpcPort: " + this.rpcPort);
     LOG.info("Reserved tbPort: " + this.tbPort);
     LOG.info("Reserved py4j gatewayServerPort: " + this.gatewayServerPort);
   }
 
-  public static void main(String[] args) {
+  public static void main(String[] args) throws Exception {
     LOG.info("TaskExecutor is running..");
-    try {
-      TaskExecutor executor = new TaskExecutor();
-      // Set up py4j
-      GatewayServer pyServer = new GatewayServer(executor, executor.gatewayServerPort);
-      executor.gatewayServerSocket.close();
-      pyServer.start();
-      boolean sanitized = executor.init(args);
-      if (sanitized) {
-        if (executor.venv != null) {
-          LOG.info("Unpacking Python virtual environment: " + executor.venv);
-          Utils.unzipArchive(executor.venv, Constants.PYTHON_VENV_DIR);
-        } else {
-          LOG.info("No virtual environment uploaded.");
-        }
-
-        executor.jobName = System.getenv(Constants.JOB_NAME);
-        executor.taskIndex = Integer.parseInt(System.getenv(Constants.TASK_INDEX));
-        executor.numTasks = Integer.parseInt(System.getenv(Constants.TASK_NUM));
-        executor.taskId = executor.jobName + ":" + executor.taskIndex;
-
-        LOG.info("Executor is running task " + executor.jobName + " " + executor.taskIndex);
-
-        executor.clusterSpec = executor.registerAndGetClusterSpec(executor.amAddress);
-        if (executor.clusterSpec == null) {
-          LOG.error("Failed to register worker with AM.");
-          throw new Exception("Failed to register worker with AM.");
-        }
-        LOG.info("Successfully registered and got cluster spec: " + executor.clusterSpec);
-
-        // Release the rpcPort and start the process
-        executor.rpcSocket.close();
-
-        if (executor.taskIndex == 0 && executor.jobName.equals("worker")) {
-          executor.registerTensorBoardUrl();
-          executor.tbSocket.close();
-        }
-
-        // Execute the user command
-        HashMap<String, String> extraEnv = new HashMap<>(executor.shellEnv);
-        switch (executor.framework) {
-          case TENSORFLOW: {
-            extraEnv.put(Constants.TB_PORT, String.valueOf(executor.tbPort));
-            extraEnv.put(Constants.PY4JGATEWAY, String.valueOf(executor.gatewayServerPort));
-            extraEnv.put(Constants.JOB_NAME, String.valueOf(executor.jobName));
-            extraEnv.put(Constants.TASK_INDEX, String.valueOf(executor.taskIndex));
-            extraEnv.put(Constants.CLUSTER_SPEC, String.valueOf(executor.clusterSpec));
-            extraEnv.put(Constants.TF_CONFIG, Utils.constructTFConfig(executor.clusterSpec,
-                executor.jobName, executor.taskIndex));
-            break;
-          }
-          case PYTORCH: {
-            extraEnv.put(Constants.RANK, String.valueOf(executor.taskIndex));
-            extraEnv.put(Constants.WORLD, String.valueOf(executor.numTasks));
-            break;
-          }
-        }
-
-        int exitCode = Utils.executeShell(executor.taskCommand, executor.timeOut, extraEnv);
-        // START - worker skew testing:
-        executor.skewAndHangIfTesting();
-        // END - worker skew testing:
-        executor.registerExecutionResult(exitCode, executor.jobName, String.valueOf(executor.taskIndex));
-
-        LOG.info("Child process exited with exit code " + exitCode);
-        System.exit(exitCode);
-      } else {
-        System.exit(-1);
-      }
-
-    } catch (Exception e) {
-      LOG.error("Failed to start task command.", e);
-      e.printStackTrace();
+    TaskExecutor executor = new TaskExecutor();
+    // Set up py4j
+    GatewayServer pyServer = new GatewayServer(executor, executor.gatewayServerPort);
+    executor.gatewayServerSocket.close();
+    pyServer.start();
+    boolean sanitized = executor.init(args);
+    if (!sanitized) {
+      LOG.fatal("Failed to initialize TaskExecutor.");
       System.exit(-1);
     }
 
+    // Localize resources to container root directory.
+    String resources = executor.tonyConf.get(TonyConfigurationKeys.getResourcesKey(executor.jobName));
+    if (resources != null) {
+      Utils.localizeResources(resources, "./", executor.hdfsConf);
+    }
+
+    if (executor.venv != null) {
+      LOG.info("Unpacking Python virtual environment: " + executor.venv);
+      Utils.unzipArchive(executor.venv, Constants.PYTHON_VENV_DIR);
+    } else {
+      LOG.info("No virtual environment uploaded.");
+    }
+
+    executor.jobName = System.getenv(Constants.JOB_NAME);
+    executor.taskIndex = Integer.parseInt(System.getenv(Constants.TASK_INDEX));
+    executor.numTasks = Integer.parseInt(System.getenv(Constants.TASK_NUM));
+    executor.taskId = executor.jobName + ":" + executor.taskIndex;
+
+    LOG.info("Executor is running task " + executor.jobName + " " + executor.taskIndex);
+
+    executor.clusterSpec = executor.registerAndGetClusterSpec(executor.amAddress);
+    if (executor.clusterSpec == null) {
+      LOG.error("Failed to register worker with AM.");
+      throw new Exception("Failed to register worker with AM.");
+    }
+    LOG.info("Successfully registered and got cluster spec: " + executor.clusterSpec);
+
+    // Release the rpcPort and start the process
+    executor.rpcSocket.close();
+
+    if (executor.taskIndex == 0 && executor.jobName.equals("worker")) {
+      executor.registerTensorBoardUrl();
+      executor.tbSocket.close();
+    }
+
+    // Execute the user command
+    HashMap<String, String> extraEnv = new HashMap<>(executor.shellEnv);
+    switch (executor.framework) {
+      case TENSORFLOW: {
+        extraEnv.put(Constants.TB_PORT, String.valueOf(executor.tbPort));
+        extraEnv.put(Constants.PY4JGATEWAY, String.valueOf(executor.gatewayServerPort));
+        extraEnv.put(Constants.JOB_NAME, String.valueOf(executor.jobName));
+        extraEnv.put(Constants.TASK_INDEX, String.valueOf(executor.taskIndex));
+        extraEnv.put(Constants.CLUSTER_SPEC, String.valueOf(executor.clusterSpec));
+        extraEnv.put(Constants.TF_CONFIG, Utils.constructTFConfig(executor.clusterSpec, executor.jobName, executor.taskIndex));
+        break;
+      }
+      case PYTORCH: {
+        extraEnv.put(Constants.RANK, String.valueOf(executor.taskIndex));
+        extraEnv.put(Constants.WORLD, String.valueOf(executor.numTasks));
+        break;
+      }
+    }
+
+    int exitCode = Utils.executeShell(executor.taskCommand, executor.timeOut, extraEnv);
+    // START - worker skew testing:
+    executor.skewAndHangIfTesting();
+    // END - worker skew testing:
+    executor.registerExecutionResult(exitCode, executor.jobName, String.valueOf(executor.taskIndex));
+
+    LOG.info("Child process exited with exit code " + exitCode);
+    System.exit(exitCode);
   }
 
   protected boolean init(String[] args) throws Exception {
@@ -172,9 +173,9 @@ public class TaskExecutor {
     amAddress = cliParser.getOptionValue("am_address", "");
     taskCommand = cliParser.getOptionValue("task_command", "exit 0");
     timeOut = tonyConf.getInt(TonyConfigurationKeys.WORKER_TIMEOUT,
-        TonyConfigurationKeys.DEFAULT_WORKER_TIMEOUT);
+                              TonyConfigurationKeys.DEFAULT_WORKER_TIMEOUT);
     hbInterval = tonyConf.getInt(TonyConfigurationKeys.TASK_HEARTBEAT_INTERVAL_MS,
-        TonyConfigurationKeys.DEFAULT_TASK_HEARTBEAT_INTERVAL_MS);
+                                 TonyConfigurationKeys.DEFAULT_TASK_HEARTBEAT_INTERVAL_MS);
     String[] shellEnvs = cliParser.getOptionValues("shell_env");
     shellEnv = Utils.parseKeyValue(shellEnvs);
     LOG.info("Task command: " + taskCommand);
@@ -183,12 +184,15 @@ public class TaskExecutor {
     if (System.getenv(Constants.YARN_CONF_PATH) != null) {
       yarnConf.addResource(new Path(System.getenv(Constants.YARN_CONF_PATH)));
     }
+    if (System.getenv(Constants.HDFS_CONF_PATH) != null) {
+      hdfsConf.addResource(new Path(System.getenv(Constants.HDFS_CONF_PATH)));
+    }
     LOG.info("Setting up Rpc client, connecting to: " + amAddress);
     proxy = ApplicationRpcClient.getInstance(amAddress.split(":")[0], Integer.parseInt(amAddress.split(":")[1]), yarnConf);
     return true;
   }
 
-  private String registerAndGetClusterSpec(String amAddress) throws Exception {
+  private String registerAndGetClusterSpec(String amAddress) throws UnknownHostException {
     LOG.info("Application Master address : " + amAddress);
     ContainerId containerId = ContainerId.fromString(System.getenv(ApplicationConstants.Environment.CONTAINER_ID.name()));
     String hostName = Utils.getCurrentHostName();
@@ -198,7 +202,7 @@ public class TaskExecutor {
 
     // Start the Heartbeater..
     hbExec.scheduleAtFixedRate(new Heartbeater(),
-        0, hbInterval, TimeUnit.MILLISECONDS);
+                               0, hbInterval, TimeUnit.MILLISECONDS);
 
     LOG.info("Connecting to " + amAddress + " to register worker spec: " + jobName + " " + taskIndex + " "
              + hostName + ":" + rpcPort);
@@ -207,7 +211,7 @@ public class TaskExecutor {
             hostName + ":" + rpcPort), 3, 0);
   }
 
-  private void registerTensorBoardUrl() throws Exception {
+  private void registerTensorBoardUrl() {
     String hostName = Utils.getCurrentHostName();
     String tbUrl = hostName + ":" + tbPort;
     LOG.info("TensorBoard address : " + tbUrl);
@@ -217,7 +221,7 @@ public class TaskExecutor {
     }
   }
 
-  private void registerExecutionResult(int exitCode, String jobName, String jobIndex) throws Exception {
+  private void registerExecutionResult(int exitCode, String jobName, String jobIndex) {
     String sessionId = System.getenv(Constants.SESSION_ID);
     String response = Utils.pollTillNonNull(
         () -> proxy.registerExecutionResult(exitCode, jobName, jobIndex, sessionId), 1, 60);
@@ -226,46 +230,46 @@ public class TaskExecutor {
     }
   }
 
-  private class Heartbeater implements Runnable {
-    int hbMissCounter = 0;
-    int numHbToMiss;
+private class Heartbeater implements Runnable {
+  int hbMissCounter = 0;
+  int numHbToMiss;
 
-    private Heartbeater() {
-      String hbMissStr = System.getenv(Constants.TEST_TASK_EXECUTOR_NUM_HB_MISS);
-      try {
-        int numMisses = Integer.parseInt(hbMissStr);
-        if (numMisses > 0) {
-          numHbToMiss = numMisses;
-        }
-      } catch (Exception e) {
-        numHbToMiss = 0;
+  private Heartbeater() {
+    String hbMissStr = System.getenv(Constants.TEST_TASK_EXECUTOR_NUM_HB_MISS);
+    try {
+      int numMisses = Integer.parseInt(hbMissStr);
+      if (numMisses > 0) {
+        numHbToMiss = numMisses;
       }
+    } catch (Exception e) {
+      numHbToMiss = 0;
     }
+  }
 
-    @Override
-    public void run() {
-      try {
-        if (hbMissCounter == 0) {
-          LOG.debug("[" + taskId + "] Sending Ping !!");
-          proxy.taskExecutorHeartbeat(taskId);
-          numFailedHBAttempts = 0;
-          hbMissCounter = numHbToMiss;
-        } else {
-          LOG.debug("[" + taskId + "] Skipping heartbeat for Testing !!");
-          hbMissCounter--;
-        }
-      } catch (Exception e) {
-        LOG.error("[" + taskId + "] Failed to send Heart Beat.", e);
-        if (++numFailedHBAttempts > MAX_NUM_FAILED_HB_ATTEMPTS) {
-          LOG.error("[" + taskId + "] Exceeded Failed Heart Beat send attempts.. going to die !!");
-          e.printStackTrace();
-          System.exit(-1);
-        } else {
-          LOG.warn("Will retry heartbeat..");
-        }
+  @Override
+  public void run() {
+    try {
+      if (hbMissCounter == 0) {
+        LOG.debug("[" + taskId + "] Sending Ping !!");
+        proxy.taskExecutorHeartbeat(taskId);
+        numFailedHBAttempts = 0;
+        hbMissCounter = numHbToMiss;
+      } else {
+        LOG.debug("[" + taskId + "] Skipping heartbeat for Testing !!");
+        hbMissCounter--;
+      }
+    } catch (Exception e) {
+      LOG.error("[" + taskId + "] Failed to send Heart Beat.", e);
+      if (++numFailedHBAttempts > MAX_NUM_FAILED_HB_ATTEMPTS) {
+        LOG.error("[" + taskId + "] Exceeded Failed Heart Beat send attempts.. going to die !!");
+        e.printStackTrace();
+        System.exit(-1);
+      } else {
+        LOG.warn("Will retry heartbeat..");
       }
     }
   }
+}
 
   //region TonyDataFeed
 
@@ -279,13 +283,13 @@ public class TaskExecutor {
   }
 
   public HdfsAvroFileSplitReader getHdfsAvroFileSplitReader(List<String> readPaths,
-      boolean useRandomShuffle)
+                                                            boolean useRandomShuffle)
       throws IOException {
     Configuration hdfsConf = new Configuration();
     hdfsConf.addResource(new Path(
         System.getenv(HADOOP_CONF_DIR) + File.separatorChar + CORE_SITE_CONF));
     return new HdfsAvroFileSplitReader(hdfsConf, readPaths, this.taskIndex,
-        this.numTasks, useRandomShuffle);
+                                       this.numTasks, useRandomShuffle);
   }
 
 

--- a/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
@@ -98,12 +98,6 @@ public class TaskExecutor {
       System.exit(-1);
     }
 
-    // Localize resources to container root directory.
-    String resources = executor.tonyConf.get(TonyConfigurationKeys.getResourcesKey(executor.jobName));
-    if (resources != null) {
-      Utils.localizeResources(resources, "./", executor.hdfsConf);
-    }
-
     if (executor.venv != null) {
       LOG.info("Unpacking Python virtual environment: " + executor.venv);
       Utils.unzipArchive(executor.venv, Constants.PYTHON_VENV_DIR);
@@ -173,9 +167,9 @@ public class TaskExecutor {
     amAddress = cliParser.getOptionValue("am_address", "");
     taskCommand = cliParser.getOptionValue("task_command", "exit 0");
     timeOut = tonyConf.getInt(TonyConfigurationKeys.WORKER_TIMEOUT,
-                              TonyConfigurationKeys.DEFAULT_WORKER_TIMEOUT);
+        TonyConfigurationKeys.DEFAULT_WORKER_TIMEOUT);
     hbInterval = tonyConf.getInt(TonyConfigurationKeys.TASK_HEARTBEAT_INTERVAL_MS,
-                                 TonyConfigurationKeys.DEFAULT_TASK_HEARTBEAT_INTERVAL_MS);
+        TonyConfigurationKeys.DEFAULT_TASK_HEARTBEAT_INTERVAL_MS);
     String[] shellEnvs = cliParser.getOptionValues("shell_env");
     shellEnv = Utils.parseKeyValue(shellEnvs);
     LOG.info("Task command: " + taskCommand);
@@ -202,7 +196,7 @@ public class TaskExecutor {
 
     // Start the Heartbeater..
     hbExec.scheduleAtFixedRate(new Heartbeater(),
-                               0, hbInterval, TimeUnit.MILLISECONDS);
+        0, hbInterval, TimeUnit.MILLISECONDS);
 
     LOG.info("Connecting to " + amAddress + " to register worker spec: " + jobName + " " + taskIndex + " "
              + hostName + ":" + rpcPort);
@@ -230,46 +224,46 @@ public class TaskExecutor {
     }
   }
 
-private class Heartbeater implements Runnable {
-  int hbMissCounter = 0;
-  int numHbToMiss;
+  private class Heartbeater implements Runnable {
+    int hbMissCounter = 0;
+    int numHbToMiss;
 
-  private Heartbeater() {
-    String hbMissStr = System.getenv(Constants.TEST_TASK_EXECUTOR_NUM_HB_MISS);
-    try {
-      int numMisses = Integer.parseInt(hbMissStr);
-      if (numMisses > 0) {
-        numHbToMiss = numMisses;
-      }
-    } catch (Exception e) {
-      numHbToMiss = 0;
-    }
-  }
-
-  @Override
-  public void run() {
-    try {
-      if (hbMissCounter == 0) {
-        LOG.debug("[" + taskId + "] Sending Ping !!");
-        proxy.taskExecutorHeartbeat(taskId);
-        numFailedHBAttempts = 0;
-        hbMissCounter = numHbToMiss;
-      } else {
-        LOG.debug("[" + taskId + "] Skipping heartbeat for Testing !!");
-        hbMissCounter--;
-      }
-    } catch (Exception e) {
-      LOG.error("[" + taskId + "] Failed to send Heart Beat.", e);
-      if (++numFailedHBAttempts > MAX_NUM_FAILED_HB_ATTEMPTS) {
-        LOG.error("[" + taskId + "] Exceeded Failed Heart Beat send attempts.. going to die !!");
-        e.printStackTrace();
-        System.exit(-1);
-      } else {
-        LOG.warn("Will retry heartbeat..");
+    private Heartbeater() {
+      String hbMissStr = System.getenv(Constants.TEST_TASK_EXECUTOR_NUM_HB_MISS);
+      try {
+        int numMisses = Integer.parseInt(hbMissStr);
+        if (numMisses > 0) {
+          numHbToMiss = numMisses;
+        }
+      } catch (Exception e) {
+        numHbToMiss = 0;
       }
     }
+
+    @Override
+    public void run() {
+      try {
+        if (hbMissCounter == 0) {
+          LOG.debug("[" + taskId + "] Sending Ping !!");
+          proxy.taskExecutorHeartbeat(taskId);
+          numFailedHBAttempts = 0;
+          hbMissCounter = numHbToMiss;
+        } else {
+          LOG.debug("[" + taskId + "] Skipping heartbeat for Testing !!");
+          hbMissCounter--;
+        }
+      } catch (Exception e) {
+        LOG.error("[" + taskId + "] Failed to send Heart Beat.", e);
+        if (++numFailedHBAttempts > MAX_NUM_FAILED_HB_ATTEMPTS) {
+          LOG.error("[" + taskId + "] Exceeded Failed Heart Beat send attempts.. going to die !!");
+          e.printStackTrace();
+          System.exit(-1);
+        } else {
+          LOG.warn("Will retry heartbeat..");
+        }
+      }
+    }
   }
-}
 
   //region TonyDataFeed
 
@@ -289,7 +283,7 @@ private class Heartbeater implements Runnable {
     hdfsConf.addResource(new Path(
         System.getenv(HADOOP_CONF_DIR) + File.separatorChar + CORE_SITE_CONF));
     return new HdfsAvroFileSplitReader(hdfsConf, readPaths, this.taskIndex,
-                                       this.numTasks, useRandomShuffle);
+        this.numTasks, useRandomShuffle);
   }
 
 

--- a/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
@@ -78,38 +78,41 @@ public class TonyClient {
   private static final Log LOG = LogFactory.getLog(TonyClient.class);
 
   private static final String APP_TYPE = "TENSORFLOW";
-  private static final String RM_APP_URL_TEMPLATE = "http://%s/cluster/app/%s";
-  private static final String HADOOP_CONF_DIR = ApplicationConstants.Environment.HADOOP_CONF_DIR.key();
+  private static final String ARCHIVE_SUFFIX = "tony_archive.zip";
   private static final String CORE_SITE_CONF = YarnConfiguration.CORE_SITE_CONFIGURATION_FILE;
+  private static final String HADOOP_CONF_DIR = ApplicationConstants.Environment.HADOOP_CONF_DIR.key();
   private static final String HDFS_SITE_CONF = "hdfs-site.xml";
+  private static final String RM_APP_URL_TEMPLATE = "http://%s/cluster/app/%s";
 
+  // Configurations
   private YarnClient yarnClient;
   private HdfsConfiguration hdfsConf = new HdfsConfiguration();
   private YarnConfiguration yarnConf = new YarnConfiguration();
   private Options opts;
 
+  // RPC
   private String amHost;
   private int amRpcPort;
   private boolean amRpcServerInitialized = false;
   private ApplicationRpcClient amRpcClient;
 
+  // Containers set up.
   private String hdfsConfAddress = null;
   private String yarnConfAddress = null;
   private long amMemory;
   private int amVCores;
   private int amGpus;
-  private String hdfsClasspath = null;
   private String taskParams = null;
   private String pythonBinaryPath = null;
   private String pythonVenv = "";
   private String executes;
+  private String hdfsClasspath;
+  private String srcDir;
   private long appTimeout;
   private boolean secureMode;
-  private String srcDir;
   private Map<String, String> shellEnv = new HashMap<>();
   private Map<String, String> containerEnv = new HashMap<>();
 
-  private static final String ARCHIVE_SUFFIX = "tony_archive.zip";
   private String archivePath;
   private String tonyFinalConfPath;
   private Configuration tonyConf;
@@ -185,10 +188,8 @@ public class TonyClient {
 
     // Set the ContainerLaunchContext to describe the Container ith which the TonyApplicationMaster is launched.
     ContainerLaunchContext amSpec =
-        createAMContainerSpec(appId,
-                              this.amMemory, this.taskParams,
-                              this.pythonBinaryPath, this.pythonVenv, this.executes, getTokens(),
-                              this.hdfsClasspath);
+        createAMContainerSpec(appId, this.amMemory, this.taskParams, this.pythonBinaryPath,
+                              this.pythonVenv, this.executes, getTokens());
     appContext.setAMContainerSpec(amSpec);
     String nodeLabel = tonyConf.get(TonyConfigurationKeys.APPLICATION_NODE_LABEL);
     if (nodeLabel != null) {
@@ -292,7 +293,10 @@ public class TonyClient {
     pythonBinaryPath = cliParser.getOptionValue("python_binary_path");
     pythonVenv = cliParser.getOptionValue("python_venv");
     executes = cliParser.getOptionValue("executes");
-    srcDir = cliParser.getOptionValue("src_dir", "src");
+
+    // src_dir & hdfs_classpath flags are for compatibility.
+    srcDir = cliParser.getOptionValue("src_dir");
+    hdfsClasspath = cliParser.getOptionValue("hdfs_classpath");
 
     if (amMemory < 0) {
       throw new IllegalArgumentException("Invalid memory specified for application master, exiting."
@@ -302,8 +306,6 @@ public class TonyClient {
       throw new IllegalArgumentException("Invalid virtual cores specified for application master, exiting."
                                          + " Specified virtual cores=" + amVCores);
     }
-
-    hdfsClasspath = cliParser.getOptionValue("hdfs_classpath");
 
     int numWorkers = tonyConf.getInt(TonyConfigurationKeys.getInstancesKey(Constants.WORKER_JOB_NAME),
         TonyConfigurationKeys.getDefaultInstances(Constants.WORKER_JOB_NAME));
@@ -350,10 +352,9 @@ public class TonyClient {
     return this.tonyConf;
   }
 
-  public ContainerLaunchContext createAMContainerSpec(ApplicationId appId, long amMemory,
-                                                      String taskParams, String pythonBinaryPath,
-                                                      String pythonVenv, String executes, ByteBuffer tokens,
-                                                      String hdfsClasspathDir) throws IOException {
+  public ContainerLaunchContext createAMContainerSpec(ApplicationId appId, long amMemory, String taskParams,
+                                                      String pythonBinaryPath, String pythonVenv, String executes,
+                                                      ByteBuffer tokens) throws IOException {
     ContainerLaunchContext amContainer = Records.newRecord(ContainerLaunchContext.class);
 
     FileSystem fs = FileSystem.get(hdfsConf);
@@ -361,18 +362,13 @@ public class TonyClient {
     Map<String, LocalResource> localResources = new HashMap<>();
     addLocalResources(fs, archivePath, LocalResourceType.FILE, Constants.TONY_ZIP_NAME, localResources);
     addLocalResources(fs, tonyFinalConfPath, LocalResourceType.FILE, Constants.TONY_FINAL_XML, localResources);
-    if (hdfsClasspathDir != null) {
-      FileStatus[] ls = fs.listStatus(new Path(hdfsClasspathDir));
-      for (FileStatus jar : ls) {
-        LocalResource resource =
-            LocalResource.newInstance(
-                ConverterUtils.getYarnUrlFromURI(URI.create(jar.getPath().toString())),
-                LocalResourceType.FILE, LocalResourceVisibility.PRIVATE,
-                jar.getLen(), jar.getModificationTime());
-
-        localResources.put(jar.getPath().getName(), resource);
+    String[] amResources = tonyConf.getStrings(TonyConfigurationKeys.getResourcesKey(Constants.AM_NAME));
+    if (null != amResources) {
+      for (String dir : amResources) {
+        Utils.addResource(dir, localResources, hdfsConf);
       }
     }
+    Utils.addResource(hdfsClasspath, localResources, hdfsConf);
     setAMEnvironment(localResources, fs);
 
     // Update absolute path with relative path
@@ -438,7 +434,7 @@ public class TonyClient {
       command.append(str).append(" ");
     }
 
-    LOG.info("Completed setting up app master command " + command.toString());
+    LOG.info("Completed setting up Application Master command " + command.toString());
     List<String> commands = new ArrayList<>();
     commands.add(command.toString());
     amContainer.setCommands(commands);
@@ -620,7 +616,7 @@ public class TonyClient {
         taskUrls = amRpcClient.getTaskUrls();
         if (!taskUrls.isEmpty()) {
           // Print TaskUrls
-          new TreeSet<TaskUrl>(taskUrls).forEach(task -> Utils.printTaskUrl(task, LOG));
+          new TreeSet<>(taskUrls).forEach(task -> Utils.printTaskUrl(task, LOG));
         }
       }
 

--- a/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
@@ -102,6 +102,10 @@ public class TonyConfigurationKeys {
     return String.format(TONY_PREFIX + "%s.gpus", jobName);
   }
 
+  public static String getResourcesKey(String jobName) {
+    return String.format(TONY_PREFIX + "%s.resources", jobName);
+  }
+
   // Worker configurations
   public static final String WORKER_PREFIX = TONY_PREFIX + "worker.";
   public static final String WORKER_TIMEOUT = WORKER_PREFIX + "timeout";

--- a/tony-core/src/main/java/com/linkedin/tony/Utils.java
+++ b/tony-core/src/main/java/com/linkedin/tony/Utils.java
@@ -4,9 +4,7 @@
  */
 package com.linkedin.tony;
 
-import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import com.linkedin.tony.rpc.TaskUrl;
@@ -282,7 +280,7 @@ public class Utils {
    */
   public static Map<String, TensorFlowContainerRequest> parseContainerRequests(Configuration conf) {
     Set<String> jobNames = conf.getValByRegex(TonyConfigurationKeys.INSTANCES_REGEX).keySet().stream()
-        .map(key -> getTaskType(key))
+        .map(Utils::getTaskType)
         .collect(Collectors.toSet());
     Map<String, TensorFlowContainerRequest> containerRequests = new HashMap<>();
     int priority = 0;
@@ -371,6 +369,22 @@ public class Utils {
       }
     } catch (IOException e) {
       LOG.error("Failed to clean up HDFS path: " + path, e);
+    }
+  }
+
+  /**
+   * Copy a list of resources delimited by comma from hdfs to local directory.
+   * @param resources a list of resources to be copied, delimited by comma.
+   * @param localDir local directory that these resources will be copied to.
+   * @param hdfsConf the configuration file for HDFS.
+   * @throws IOException exception thrown during file copies.
+   */
+  public static void localizeResources(String resources, String localDir, Configuration hdfsConf) throws IOException {
+    String[] resourceArray = resources.split(",");
+    for (String resource : resourceArray) {
+      Path re = new Path(resource);
+      FileSystem fs = FileSystem.get(hdfsConf);
+      fs.copyToLocalFile(re, new Path(localDir));
     }
   }
 }

--- a/tony-core/src/main/java/com/linkedin/tony/Utils.java
+++ b/tony-core/src/main/java/com/linkedin/tony/Utils.java
@@ -377,19 +377,23 @@ public class Utils {
   }
 
   /**
-   * Copy a list of resources delimited by comma from hdfs to local directory.
-   * @param directory the directory whose contents will be localized.
+   * Add files inside a path to local resources. If the path is a directory, its first level files will be added
+   * to the local resources. Note that we don't add nested files.
+   * @param path the directory whose contents will be localized.
    * @param hdfsConf the configuration file for HDFS.
-   * @throws IOException exception thrown during file copies.
    */
-  public static void addResource(String directory,
+  public static void addResource(String path,
                                  Map<String, LocalResource> resourcesMap,
                                  Configuration hdfsConf) {
     try {
       FileSystem fs = FileSystem.get(hdfsConf);
-      if (directory != null) {
-        FileStatus[] ls = fs.listStatus(new Path(directory));
+      if (path != null) {
+        FileStatus[] ls = fs.listStatus(new Path(path));
         for (FileStatus jar : ls) {
+          // We only add first level files.
+          if (jar.isDirectory()) {
+            continue;
+          }
           LocalResource resource = LocalResource.newInstance(ConverterUtils.getYarnUrlFromURI(URI.create(jar.getPath().toString())),
                                                              LocalResourceType.FILE, LocalResourceVisibility.PRIVATE,
                                                              jar.getLen(), jar.getModificationTime());
@@ -397,7 +401,7 @@ public class Utils {
         }
       }
     } catch (IOException exception) {
-      LOG.error("Failed to add " + directory + " to local resources.", exception);
+      LOG.error("Failed to add " + path + " to local resources.", exception);
     }
   }
 }

--- a/tony-core/src/main/resources/tony-default.xml
+++ b/tony-core/src/main/resources/tony-default.xml
@@ -153,14 +153,6 @@
   </property>
 
   <property>
-    <description>Resources that will be localized to the container that executes the job. Delimited by comma.
-      Example: /user/tony/resource1
-    </description>
-    <name>tony.worker.resources</name>
-    <value></value>
-  </property>
-
-  <property>
     <description>Number of workers to request.</description>
     <name>tony.worker.instances</name>
     <value>1</value>

--- a/tony-core/src/main/resources/tony-default.xml
+++ b/tony-core/src/main/resources/tony-default.xml
@@ -153,6 +153,12 @@
   </property>
 
   <property>
+    <description>Resources that will be localized to the container that executes the job. Delimited by comma.</description>
+    <name>tony.worker.resources</name>
+    <value>hdfs://mycluster:9000/user/tony/resource1,hdfs://mycluster:9000/user/tony/resources2</value>
+  </property>
+
+  <property>
     <description>Number of workers to request.</description>
     <name>tony.worker.instances</name>
     <value>1</value>

--- a/tony-core/src/main/resources/tony-default.xml
+++ b/tony-core/src/main/resources/tony-default.xml
@@ -153,9 +153,11 @@
   </property>
 
   <property>
-    <description>Resources that will be localized to the container that executes the job. Delimited by comma.</description>
+    <description>Resources that will be localized to the container that executes the job. Delimited by comma.
+      Example: /user/tony/resource1
+    </description>
     <name>tony.worker.resources</name>
-    <value>hdfs://mycluster:9000/user/tony/resource1,hdfs://mycluster:9000/user/tony/resources2</value>
+    <value></value>
   </property>
 
   <property>

--- a/tony-core/src/test/java/com/linkedin/tony/TestTonyConfigurationFields.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestTonyConfigurationFields.java
@@ -25,10 +25,12 @@ public class TestTonyConfigurationFields extends TestConfigurationFieldsBase {
     xmlPropsToSkipCompare.add(TonyConfigurationKeys.getInstancesKey(Constants.PS_JOB_NAME));
     xmlPropsToSkipCompare.add(TonyConfigurationKeys.getMemoryKey(Constants.PS_JOB_NAME));
     xmlPropsToSkipCompare.add(TonyConfigurationKeys.getVCoresKey(Constants.PS_JOB_NAME));
+    xmlPropsToSkipCompare.add(TonyConfigurationKeys.getResourcesKey(Constants.PS_JOB_NAME));
     xmlPropsToSkipCompare.add(TonyConfigurationKeys.getInstancesKey(Constants.WORKER_JOB_NAME));
     xmlPropsToSkipCompare.add(TonyConfigurationKeys.getMemoryKey(Constants.WORKER_JOB_NAME));
     xmlPropsToSkipCompare.add(TonyConfigurationKeys.getVCoresKey(Constants.WORKER_JOB_NAME));
     xmlPropsToSkipCompare.add(TonyConfigurationKeys.getGPUsKey(Constants.WORKER_JOB_NAME));
+    xmlPropsToSkipCompare.add(TonyConfigurationKeys.getResourcesKey(Constants.WORKER_JOB_NAME));
     configurationPropsToSkipCompare.add(TonyConfigurationKeys.DOCKER_IMAGE);
   }
 


### PR DESCRIPTION
Enable TonY to localize a list of resources to local container before starting the training job.

This is needed to make user's life easier by automatically downloading the required resources from HDFS to local container before starting a user's script.

Some cosmetic changes.