### PR TITLE
Replace junit import with testNG

### DIFF
--- a/tony-cli/src/test/java/com/linkedin/tony/TestClusterSubmitter.java
+++ b/tony-cli/src/test/java/com/linkedin/tony/TestClusterSubmitter.java
@@ -7,8 +7,8 @@ package com.linkedin.tony;
 import com.linkedin.tony.cli.ClusterSubmitter;
 import org.testng.annotations.Test;
 
-import static junit.framework.Assert.*;
 import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
 
 
 public class TestClusterSubmitter {

--- a/tony-history-server/build.gradle
+++ b/tony-history-server/build.gradle
@@ -37,6 +37,7 @@ dependencies {
   playTest deps.external.assertj
   playTest deps.external.awaitility
   playTest deps.external.mockito
+  playTest deps.external.testng
 }
 
 repositories {

--- a/tony-history-server/test/controllers/BrowserTest.java
+++ b/tony-history-server/test/controllers/BrowserTest.java
@@ -1,13 +1,13 @@
 package controllers;
 
 import com.google.common.collect.ImmutableMap;
-import org.junit.Test;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 import play.Application;
 import play.test.Helpers;
 import play.test.TestBrowser;
 import play.test.WithBrowser;
 
-import static org.junit.Assert.assertTrue;
 import static play.test.Helpers.*;
 
 
@@ -24,6 +24,6 @@ public class BrowserTest extends WithBrowser {
   @Test
   public void test() {
     browser.goTo("http://localhost:" + play.api.test.Helpers.testServerPort());
-    assertTrue(browser.pageSource().contains("Tony History Server"));
+    Assert.assertTrue(browser.pageSource().contains("Tony History Server"));
   }
 }

--- a/tony-history-server/test/controllers/JobConfigPageControllerTest.java
+++ b/tony-history-server/test/controllers/JobConfigPageControllerTest.java
@@ -1,11 +1,11 @@
 package controllers;
 
-import org.junit.Test;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 import play.Application;
 import play.inject.guice.GuiceApplicationBuilder;
 import play.test.WithApplication;
 
-import static org.junit.Assert.*;
 import static play.mvc.Http.Status.*;
 
 
@@ -19,6 +19,6 @@ public class JobConfigPageControllerTest extends WithApplication {
   @Test
   public void testIndex() {
     // TODO: Write tests
-    assertEquals(OK, OK);
+    Assert.assertEquals(OK, OK);
   }
 }

--- a/tony-history-server/test/controllers/JobsMetadataPageControllerTest.java
+++ b/tony-history-server/test/controllers/JobsMetadataPageControllerTest.java
@@ -1,13 +1,13 @@
 package controllers;
 
-import org.junit.Test;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 import play.Application;
 import play.inject.guice.GuiceApplicationBuilder;
 import play.mvc.Http;
 import play.mvc.Result;
 import play.test.WithApplication;
 
-import static org.junit.Assert.assertEquals;
 import static play.mvc.Http.Status.OK;
 import static play.test.Helpers.GET;
 import static play.test.Helpers.route;
@@ -25,6 +25,6 @@ public class JobsMetadataPageControllerTest extends WithApplication {
     Http.RequestBuilder request = new Http.RequestBuilder().method(GET).uri("/");
 
     Result result = route(app, request);
-    assertEquals(OK, result.status());
+    Assert.assertEquals(OK, result.status());
   }
 }

--- a/tony-history-server/test/utils/TestHdfsUtils.java
+++ b/tony-history-server/test/utils/TestHdfsUtils.java
@@ -7,10 +7,10 @@ import java.util.List;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 
@@ -23,7 +23,7 @@ public class TestHdfsUtils {
     try {
       fs = FileSystem.get(conf);
     } catch (Exception e) {
-      fail("Failed setting up FileSystem object");
+      Assert.fail("Failed setting up FileSystem object");
     }
   }
 
@@ -31,14 +31,14 @@ public class TestHdfsUtils {
   public void testPathExists_true() {
     Path exists = new Path("./test/resources/file.txt");
 
-    assertTrue(HdfsUtils.pathExists(fs, exists));
+    Assert.assertTrue(HdfsUtils.pathExists(fs, exists));
   }
 
   @Test
   public void testPathExists_false() {
     Path invalidPath = new Path("/invalid/path");
 
-    assertFalse(HdfsUtils.pathExists(fs, invalidPath));
+    Assert.assertFalse(HdfsUtils.pathExists(fs, invalidPath));
   }
 
   @Test
@@ -48,21 +48,21 @@ public class TestHdfsUtils {
 
     when(mockFs.exists(invalidPath)).thenThrow(new IOException("IO Excpt"));
 
-    assertFalse(HdfsUtils.pathExists(mockFs, invalidPath));
+    Assert.assertFalse(HdfsUtils.pathExists(mockFs, invalidPath));
   }
 
   @Test
   public void testContentOfHdfsFile_withContent() {
     Path filePath = new Path("./test/resources/file.txt");
 
-    assertEquals("someContent", HdfsUtils.contentOfHdfsFile(fs, filePath));
+    Assert.assertEquals("someContent", HdfsUtils.contentOfHdfsFile(fs, filePath));
   }
 
   @Test
   public void testContentOfHdfsFile_noContent() {
     Path filePath = new Path("./test/resources/empty.txt");
 
-    assertEquals("", HdfsUtils.contentOfHdfsFile(fs, filePath));
+    Assert.assertEquals("", HdfsUtils.contentOfHdfsFile(fs, filePath));
   }
 
   @Test
@@ -72,14 +72,14 @@ public class TestHdfsUtils {
 
     when(mockFs.exists(filePath)).thenThrow(new IOException("IO Excpt"));
 
-    assertEquals("", HdfsUtils.contentOfHdfsFile(fs, filePath));
+    Assert.assertEquals("", HdfsUtils.contentOfHdfsFile(fs, filePath));
   }
 
   @Test
   public void testGetMetadataFilePaths_emptyHistoryFolder() {
     String histFolder = "./test/resources/emptyHistFolder";
 
-    assertEquals(new ArrayList<Path>(), HdfsUtils.getMetadataFilePaths(fs, histFolder));
+    Assert.assertEquals(new ArrayList<Path>(), HdfsUtils.getMetadataFilePaths(fs, histFolder));
   }
 
   @Test
@@ -97,8 +97,8 @@ public class TestHdfsUtils {
     List<Path> actualRes = HdfsUtils.getMetadataFilePaths(fs, histFolder);
     Collections.sort(actualRes);
 
-    assertEquals(expectedRes, actualRes);
-    assertEquals(expectedRes.size(), actualRes.size());
+    Assert.assertEquals(expectedRes, actualRes);
+    Assert.assertEquals(expectedRes.size(), actualRes.size());
   }
 
   @Test
@@ -109,7 +109,7 @@ public class TestHdfsUtils {
     when(mockFs.listStatus(new Path(histFolder))).thenThrow(new IOException("IO Excpt"));
     List<Path> actualRes = HdfsUtils.getMetadataFilePaths(mockFs, histFolder);
 
-    assertEquals(new ArrayList<Path>(), actualRes);
-    assertEquals(0, actualRes.size());
+    Assert.assertEquals(new ArrayList<Path>(), actualRes);
+    Assert.assertEquals(0, actualRes.size());
   }
 }


### PR DESCRIPTION
However, when I did a code search, I found all jobhistory tests import junit @erwa  @pdtran3k6 , maybe @pdtran3k6 should also clean up those tests to use testNG.