### PR TITLE
Add more logging for token fetching logic

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
@@ -35,6 +35,7 @@ import org.apache.commons.cli.ParseException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -546,7 +547,7 @@ public class TonyClient implements AutoCloseable {
     if (!this.secureMode) {
       return null;
     }
-    LOG.info("Running in secure cluster mode. Fetching delegation token..");
+    LOG.info("Running with secure cluster mode. Fetching delegation tokens..");
     Credentials cred = new Credentials();
     String fileLocation = System.getenv(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION);
     if (fileLocation != null) {
@@ -563,19 +564,22 @@ public class TonyClient implements AutoCloseable {
                                                                             YarnConfiguration.DEFAULT_RM_ADDRESS,
                                                                             YarnConfiguration.DEFAULT_RM_PORT));
       LOG.info("RM delegation token fetched.");
-      LOG.info("Fetching HDFS delegation token..");
+      String defaultFS = hdfsConf.get(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY,
+          CommonConfigurationKeysPublic.FS_DEFAULT_NAME_DEFAULT);
+      LOG.info("Fetching HDFS delegation token for default namenode: " + defaultFS);
       FileSystem fs = FileSystem.get(hdfsConf);
       final Token<?> fsToken = fs.getDelegationToken(tokenRenewer);
       if (fsToken == null) {
         throw new RuntimeException("Failed to get FS delegation token for default FS.");
       }
-      LOG.info("HDFS delegation token fetched.");
+      LOG.info("Default HDFS delegation token fetched.");
       cred.addToken(rmToken.getService(), rmToken);
       cred.addToken(fsToken.getService(), fsToken);
       String[] otherNamenodes = tonyConf.getStrings(TonyConfigurationKeys.OTHER_NAMENODES_TO_ACCESS);
       if (otherNamenodes != null) {
         for (String nnUri : otherNamenodes) {
           String namenodeUri = nnUri.trim();
+          LOG.info("Fetching HDFS delegation token for " + nnUri);
           FileSystem otherFS = FileSystem.get(new URI(namenodeUri), hdfsConf);
           final Token<?> otherFSToken = otherFS.getDelegationToken(tokenRenewer);
           if (otherFSToken == null) {


### PR DESCRIPTION
From #74 , if user runs in insecure cluster but didn't disable security check, tony throws exception without enough information.