### PR TITLE
Add back "distribution" plugin in tony-history-server

### DIFF
--- a/tony-history-server/build.gradle
+++ b/tony-history-server/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: "play"
 apply plugin: "idea"
+apply plugin: "distribution"
 
 model {
   components {


### PR DESCRIPTION
Apparently, it does some set up so that the Ivy generated includes the zip and tar artifacts created by the createPlayBinaryZipDist and createPlayBinaryTarDist tasks.