### PR TITLE
LIHADOOP-41388: Inject Azkaban metadata to TonY configuration

### DIFF
--- a/tony-cli/build.gradle
+++ b/tony-cli/build.gradle
@@ -14,6 +14,7 @@ shadowJar {
     exclude(dependency('com.sun.jersey.contribs:'))
     exclude(dependency('org.apache.hadoop:'))
   }
+  zip64 true
 }
 
 build.dependsOn(shadowJar)

--- a/tony-core/build.gradle
+++ b/tony-core/build.gradle
@@ -4,15 +4,17 @@ apply plugin: 'com.google.protobuf'
 dependencies {
   compile project(':tony-mini')
 
+  compile deps.azkaban.az_core
+  compile deps.azkaban.az_hadoop_jobtype_plugin
   compile deps.external.jackson_databind
   compile deps.external.py4j
   compile deps.external.text
+  compile deps.external.zip4j
   compile deps.hadoop.common
   compile deps.hadoop.hdfs
   compile deps.hadoop.yarn_api
   compile deps.hadoop.yarn_client
   compile deps.hadoop.yarn_common
-  compile deps.external.zip4j
 
   testCompile deps.external.avro
   testCompile deps.external.testng

--- a/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
@@ -4,6 +4,8 @@
  */
 package com.linkedin.tony;
 
+import azkaban.jobtype.HadoopConfigurationInjector;
+import azkaban.utils.Props;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -714,18 +716,25 @@ public class TonyClient implements AutoCloseable {
 
   public static void main(String[] args) {
     int exitCode = 0;
+
+    // Adds hadoop-inject.xml as a default resource so Azkaban metadata will be present in the new Configuration created
+    HadoopConfigurationInjector.injectResources(new Props() /* ignored */);
     try (TonyClient client = new TonyClient(new Configuration())) {
       boolean sanityCheck = client.init(args);
       if (!sanityCheck) {
-        LOG.fatal("Failed to parse arguments.");
+        LOG.fatal("Failed to init client.");
+        exitCode = -1;
       }
-      exitCode = client.start();
-      if (client.amRpcClient != null) {
-        client.amRpcClient.finishApplication();
+
+      if (exitCode == 0) {
+        exitCode = client.start();
+        if (client.amRpcClient != null) {
+          client.amRpcClient.finishApplication();
+        }
       }
     } catch (ParseException | IOException | YarnException e) {
-      LOG.fatal("Failed to init client.", e);
-      System.exit(-1);
+      LOG.fatal("Encountered exception while initializing client or finishing application.", e);
+      exitCode = -1;
     }
     System.exit(exitCode);
   }


### PR DESCRIPTION
Tested on our test cluster. Verified that `/system/tony-history/application_XXX_XXX/config.xml` now contains Azkaban metadata such as

* azkaban.link.execution.url
* azkaban.link.job.url
* azkaban.flow.projectname

etc.