### PR TITLE
Fix #95 Failed to run PyTorch mnist example in GCP

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
@@ -75,8 +75,6 @@ public class TaskExecutor {
     this.tbPort = this.tbSocket.getLocalPort();
     this.gatewayServerSocket = new ServerSocket(0);
     this.gatewayServerPort = this.gatewayServerSocket.getLocalPort();
-    this.framework = MLFramework.valueOf(
-        tonyConf.get(TonyConfigurationKeys.FRAMEWORK_NAME, TonyConfigurationKeys.DEFAULT_FRAMEWORK_NAME).toUpperCase());
 
     LOG.info("Reserved rpcPort: " + this.rpcPort);
     LOG.info("Reserved tbPort: " + this.tbPort);
@@ -129,6 +127,7 @@ public class TaskExecutor {
     HashMap<String, String> extraEnv = new HashMap<>(executor.shellEnv);
     switch (executor.framework) {
       case TENSORFLOW: {
+        LOG.info("Setting TensorFlow jobs..");
         extraEnv.put(Constants.TB_PORT, String.valueOf(executor.tbPort));
         extraEnv.put(Constants.PY4JGATEWAY, String.valueOf(executor.gatewayServerPort));
         extraEnv.put(Constants.JOB_NAME, String.valueOf(executor.jobName));
@@ -138,6 +137,7 @@ public class TaskExecutor {
         break;
       }
       case PYTORCH: {
+        LOG.info("Setting PyTorch jobs..");
         extraEnv.put(Constants.RANK, String.valueOf(executor.taskIndex));
         extraEnv.put(Constants.WORLD, String.valueOf(executor.numTasks));
         break;
@@ -172,6 +172,9 @@ public class TaskExecutor {
     shellEnv = Utils.parseKeyValue(shellEnvs);
     LOG.info("Task command: " + taskCommand);
     venv = cliParser.getOptionValue("venv");
+    framework = MLFramework.valueOf(
+        tonyConf.get(TonyConfigurationKeys.FRAMEWORK_NAME, TonyConfigurationKeys.DEFAULT_FRAMEWORK_NAME).toUpperCase());
+
     Utils.unzipArchive(Constants.TONY_ZIP_NAME, "./");
     if (System.getenv(Constants.YARN_CONF_PATH) != null) {
       yarnConf.addResource(new Path(System.getenv(Constants.YARN_CONF_PATH)));

--- a/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
@@ -138,6 +138,12 @@ public class TaskExecutor {
       }
       case PYTORCH: {
         LOG.info("Setting PyTorch jobs..");
+        String initMethod = Utils.parseClusterSpecForPytorch(executor.clusterSpec);
+        if (initMethod == null) {
+          System.exit(-1);
+        }
+        LOG.info("Set coordinator address: " + initMethod);
+        extraEnv.put(Constants.INIT_METHOD, String.valueOf(initMethod));
         extraEnv.put(Constants.RANK, String.valueOf(executor.taskIndex));
         extraEnv.put(Constants.WORLD, String.valueOf(executor.numTasks));
         break;
@@ -187,7 +193,7 @@ public class TaskExecutor {
     return true;
   }
 
-  private String registerAndGetClusterSpec(String amAddress) throws UnknownHostException {
+  private String registerAndGetClusterSpec(String amAddress) {
     LOG.info("Application Master address : " + amAddress);
     ContainerId containerId = ContainerId.fromString(System.getenv(ApplicationConstants.Environment.CONTAINER_ID.name()));
     String hostName = Utils.getCurrentHostName();

--- a/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
@@ -127,7 +127,7 @@ public class TaskExecutor {
     HashMap<String, String> extraEnv = new HashMap<>(executor.shellEnv);
     switch (executor.framework) {
       case TENSORFLOW: {
-        LOG.info("Setting TensorFlow jobs..");
+        LOG.info("Setting up TensorFlow jobs..");
         extraEnv.put(Constants.TB_PORT, String.valueOf(executor.tbPort));
         extraEnv.put(Constants.PY4JGATEWAY, String.valueOf(executor.gatewayServerPort));
         extraEnv.put(Constants.JOB_NAME, String.valueOf(executor.jobName));
@@ -137,12 +137,12 @@ public class TaskExecutor {
         break;
       }
       case PYTORCH: {
-        LOG.info("Setting PyTorch jobs..");
+        LOG.info("Setting up PyTorch jobs..");
         String initMethod = Utils.parseClusterSpecForPytorch(executor.clusterSpec);
         if (initMethod == null) {
           System.exit(-1);
         }
-        LOG.info("Set coordinator address: " + initMethod);
+        LOG.info("Init method is: " + initMethod);
         extraEnv.put(Constants.INIT_METHOD, String.valueOf(initMethod));
         extraEnv.put(Constants.RANK, String.valueOf(executor.taskIndex));
         extraEnv.put(Constants.WORLD, String.valueOf(executor.numTasks));

--- a/tony-core/src/main/java/com/linkedin/tony/TonyApplicationMaster.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyApplicationMaster.java
@@ -1043,21 +1043,14 @@ public class TonyApplicationMaster {
       task.addContainer(container);
       LOG.info("Setting Container [" + container.getId() + "] for task [" + task.getId() + "]..");
 
-      // Add additional environment vars.
-      switch (framework) {
-        case TENSORFLOW: {
-          containerShellEnv.put(Constants.JOB_NAME, task.getJobName());
-          containerShellEnv.put(Constants.TASK_INDEX, task.getTaskIndex());
-          containerShellEnv.put(Constants.TASK_NUM, String.valueOf(numTotalWorkerTasks));
-          break;
-        }
-        case PYTORCH: {
-          containerShellEnv.put(Constants.RANK, task.getTaskIndex());
-          containerShellEnv.put(Constants.WORLD, String.valueOf(numTotalWorkerTasks));
-          break;
-        }
-      }
-
+      /*
+       * Add additional environment vars. We always set job_name task_index & task_num and
+       * task_num and TaskExecutor is responsible for setting up the actual shell environment
+       * for different deep learning frameworks.
+       */
+      containerShellEnv.put(Constants.JOB_NAME, task.getJobName());
+      containerShellEnv.put(Constants.TASK_INDEX, task.getTaskIndex());
+      containerShellEnv.put(Constants.TASK_NUM, String.valueOf(numTotalWorkerTasks));
       List<String> commands = new ArrayList<>();
 
       List<CharSequence> arguments = new ArrayList<>(5);

--- a/tony-core/src/main/java/com/linkedin/tony/TonyApplicationMaster.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyApplicationMaster.java
@@ -767,12 +767,6 @@ public class TonyApplicationMaster {
         task.setHostPort(spec);
         registeredTasks.add(taskId);
 
-        // Use chief worker as coordinator.
-        if (taskId.equals(COORDINATOR_ID) && framework == MLFramework.PYTORCH) {
-          // Hard coded to use tcp:// as backend. TODO: support other backend as well later.
-          shellEnv.put(Constants.INIT_METHOD, COMMUNICATION_BACKEND + spec);
-        }
-
         // HB Registration should happen only after worker registration..
         // The Task registration timeout will take care of rescheduling the task
         // on another node..

--- a/tony-core/src/main/java/com/linkedin/tony/Utils.java
+++ b/tony-core/src/main/java/com/linkedin/tony/Utils.java
@@ -297,10 +297,11 @@ public class Utils {
           TonyConfigurationKeys.DEFAULT_VCORES);
       int gpus = conf.getInt(TonyConfigurationKeys.getGPUsKey(jobName),
           TonyConfigurationKeys.DEFAULT_GPUS);
-      // The priority of different task types MUST be different.
-      // Otherwise the requests will overwrite each other on the RM
-      // scheduling side. See YARN-7631 for details.
-      // For now we set the priorities of different task types arbitrarily.
+      /* The priority of different task types MUST be different.
+       * Otherwise the requests will overwrite each other on the RM
+       * scheduling side. See YARN-7631 for details.
+       * For now we set the priorities of different task types arbitrarily.
+       */
       if (numInstances > 0) {
         containerRequests.put(jobName, new TensorFlowContainerRequest(jobName, numInstances, memory, vCores, gpus, priority++));
       }
@@ -414,6 +415,19 @@ public class Utils {
       return;
     }
     LOG.info("Completed worker tasks: " + completedWTasks.get() + " out of " + totalWTasks + " worker tasks." );
+  }
+
+  public static String parseClusterSpecForPytorch(String clusterSpec) throws IOException {
+    ObjectMapper objectMapper = new ObjectMapper();
+    Map<String, List<String>> clusterSpecMap =
+        objectMapper.readValue(clusterSpec, new TypeReference<Map<String, List<String>>>(){});
+    String chiefWorkerAddress = clusterSpecMap.get(Constants.WORKER_JOB_NAME).get(0);
+    if (chiefWorkerAddress == null) {
+      LOG.error("Failed to get chief worker address from cluster spec.");
+      return null;
+    }
+    return Constants.COMMUNICATION_BACKEND + chiefWorkerAddress;
+
   }
 
   private Utils() { }

--- a/tony-core/src/test/java/com/linkedin/tony/TestTonyE2E.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestTonyE2E.java
@@ -134,7 +134,7 @@ public class TestTonyE2E {
   public void testPSWorkerTrainingPyTorchShouldPass() throws ParseException {
     client.init(new String[]{
         "--src_dir", "tony-core/src/test/resources/",
-        "--executes", "tony-core/src/test/resources/exit_0_check_env_pytorchenv.py",
+        "--executes", "tony-core/src/test/resources/exit_0_check_pytorchenv.py",
         "--hdfs_classpath", "/yarn/libs",
         "--python_binary_path", "python",
         "--shell_env", "ENV_CHECK=ENV_CHECK",

--- a/tony-core/src/test/java/com/linkedin/tony/TestTonyE2E.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestTonyE2E.java
@@ -138,7 +138,9 @@ public class TestTonyE2E {
         "--hdfs_classpath", "/yarn/libs",
         "--python_binary_path", "python",
         "--shell_env", "ENV_CHECK=ENV_CHECK",
-        "--conf","tony.application.framework=pytorch",
+        "--conf", "tony.application.framework=pytorch",
+        "--conf", "tony.ps.instances=0",
+        "--conf", "tony.worker.instances=2",
         "--container_env", Constants.SKIP_HADOOP_PATH + "=true"
     });
     int exitCode = client.start();

--- a/tony-core/src/test/java/com/linkedin/tony/TestTonyE2E.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestTonyE2E.java
@@ -131,6 +131,21 @@ public class TestTonyE2E {
   }
 
   @Test
+  public void testPSWorkerTrainingPyTorchShouldPass() throws ParseException {
+    client.init(new String[]{
+        "--src_dir", "tony-core/src/test/resources/",
+        "--executes", "tony-core/src/test/resources/exit_0_check_env_pytorchenv.py",
+        "--hdfs_classpath", "/yarn/libs",
+        "--python_binary_path", "python",
+        "--shell_env", "ENV_CHECK=ENV_CHECK",
+        "--conf","tony.application.framework=pytorch",
+        "--container_env", Constants.SKIP_HADOOP_PATH + "=true"
+    });
+    int exitCode = client.start();
+    Assert.assertEquals(exitCode, 0);
+  }
+
+  @Test
   public void testPSWorkerTrainingShouldFail() throws ParseException {
     client.init(new String[]{
         "--src_dir", "tony-core/src/test/resources/",

--- a/tony-core/src/test/resources/exit_0_check_pytorchenv.py
+++ b/tony-core/src/test/resources/exit_0_check_pytorchenv.py
@@ -16,9 +16,14 @@ ch = logging.StreamHandler(sys.stdout)
 ch.setLevel(logging.DEBUG)
 log_root.addHandler(ch)
 
-if os.environ.get('RANK') is not None and os.environ.get('WORLD') is not None:
-    logging.info('Found RANK and WORLD environment variable.')
-    exit(0)
-else:
-    logging.error('Failed to find RANK or WORLD environment variable')
+if os.environ.get('RANK') is None:
+    logging.error('Failed to find RANK environment variable')
     exit(1)
+if os.environ.get('WORLD') is None:
+    logging.error('Failed to find WORLD environment variable')
+    exit(1)
+if os.environ.get('INIT_METHOD') is None:
+    logging.error('Failed to find INIT_METHOD environment variable')
+    exit(1)
+
+exit(0)

--- a/tony-core/src/test/resources/exit_0_check_pytorchenv.py
+++ b/tony-core/src/test/resources/exit_0_check_pytorchenv.py
@@ -1,0 +1,24 @@
+"""
+Copyright 2018 LinkedIn Corporation. All rights reserved. Licensed under the BSD-2 Clause license.
+See LICENSE in the project root for license information.
+"""
+import time
+import logging
+import os
+import sys
+
+time.sleep(1)
+
+# Set up logging.
+log_root = logging.getLogger()
+log_root.setLevel(logging.DEBUG)
+ch = logging.StreamHandler(sys.stdout)
+ch.setLevel(logging.DEBUG)
+log_root.addHandler(ch)
+
+if os.environ.get('RANK') is not None and os.environ.get('WORLD') is not None:
+    logging.info('Found RANK and WORLD environment variable.')
+    exit(0)
+else:
+    logging.error('Failed to find RANK or WORLD environment variable')
+    exit(1)

--- a/tony-examples/mnist-pytorch/README.md
+++ b/tony-examples/mnist-pytorch/README.md
@@ -28,15 +28,24 @@ zip -r venv.zip venv
 TonY only requires YARN, not HDFS. Please see the [open-source documentation](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/SingleCluster.html) on how to set YARN up.
 
 
-### Disabling security
+### Config TonY job for PyTorch
 
-If your Hadoop cluster is not running with security enabled (e.g.: for local testing), you can disable security by creating a config file as follows:
+You don't need parameter servers for distributed PyTorch training and if your Hadoop cluster is not running with security enabled (e.g.: for local testing), you
+need to disable the security check. Here is a sample of the config:
 
 ```
 <configuration>
   <property>
     <name>tony.application.security.enabled</name>
     <value>false</value>
+  </property>
+  <property>
+    <name>tony.ps.instances</name>
+    <value>0</value>
+  </property>
+  <property>
+    <name>tony.worker.instances</name>
+    <value>2</value>
   </property>
   <property>
     <name>tony.application.framework</name>


### PR DESCRIPTION
When we supported PyTorch, I didn't add a break for switch thus we always set `Constants.JOB_NAME ` and others (unintentionally). After the break cases were fixed by Jonathan, we didn't update TaskExecutor to pick up the correct env thus resulting in null pointer exception. This PR unify a same set of env for distributed training and it is up to TaskExecutor to reassign actual values to different local environment variables.