### PR TITLE
Fix a missing file name for python_venv_zip

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
@@ -171,7 +171,7 @@ public class TonyClient implements AutoCloseable {
     }
 
     if (pythonVenv != null) {
-      uploadFileAndSetConfResources(appResourcesPath, new Path(pythonVenv), tonyConf, fs);
+      uploadFileAndSetConfResources(appResourcesPath, new Path(pythonVenv), Constants.PYTHON_VENV_ZIP, tonyConf, fs);
     }
 
     if (yarnConfAddress != null) {

--- a/tony-core/src/test/java/com/linkedin/tony/TestTonyE2E.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestTonyE2E.java
@@ -120,11 +120,11 @@ public class TestTonyE2E {
   public void testPSWorkerTrainingShouldPass() throws ParseException {
     client.init(new String[]{
         "--src_dir", "tony-core/src/test/resources/",
-        "--executes", "exit_0_check_env.py",
+        "--executes", "'python check_env_and_venv.py'",
         "--hdfs_classpath", "/yarn/libs",
-        "--python_binary_path", "python",
         "--shell_env", "ENV_CHECK=ENV_CHECK",
-        "--container_env", Constants.SKIP_HADOOP_PATH + "=true"
+        "--container_env", Constants.SKIP_HADOOP_PATH + "=true",
+        "--python_venv", "tony-core/src/test/resources/test.zip",
     });
     int exitCode = client.start();
     Assert.assertEquals(exitCode, 0);

--- a/tony-core/src/test/resources/check_env_and_venv.py
+++ b/tony-core/src/test/resources/check_env_and_venv.py
@@ -1,0 +1,31 @@
+"""
+Copyright 2018 LinkedIn Corporation. All rights reserved. Licensed under the BSD-2 Clause license.
+See LICENSE in the project root for license information.
+"""
+import time
+import logging
+import os
+import sys
+
+time.sleep(1)
+
+# Set up logging.
+log_root = logging.getLogger()
+log_root.setLevel(logging.DEBUG)
+ch = logging.StreamHandler(sys.stdout)
+ch.setLevel(logging.DEBUG)
+log_root.addHandler(ch)
+
+if not os.path.isfile('test.zip'):
+    logging.error('test.zip doesn\'t exist')
+    exit(-1)
+if not os.path.isfile('venv/123.xml'):
+    logging.error('venv/123.xml doesn\'t exist')
+    exit(-1)
+
+if os.environ['ENV_CHECK'] == 'ENV_CHECK':
+    logging.info('Found ENV_CHECK environment variable.')
+    exit(0)
+else:
+    logging.error('Failed to find ENV_CHECK environment variable')
+    exit(1)

--- a/tony-core/src/test/resources/exit_0.py
+++ b/tony-core/src/test/resources/exit_0.py
@@ -4,10 +4,5 @@ See LICENSE in the project root for license information.
 """
 import time
 
-
-def return_zero():
-    time.sleep(1)
-    return 0
-
-
-exit(return_zero())
+time.sleep(1)
+exit(0)


### PR DESCRIPTION
The name of the python venv zip file is missing from last refactoring and we don't find the python virtual env in containers.