### PR TITLE
Fix TonY History Server ResourceManager link #153

### DIFF
--- a/tony-history-server/app/hadoop/Configuration.java
+++ b/tony-history-server/app/hadoop/Configuration.java
@@ -4,9 +4,11 @@ import java.io.File;
 import javax.inject.Singleton;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
-import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import play.Logger;
+
+import static org.apache.hadoop.yarn.api.ApplicationConstants.Environment.HADOOP_CONF_DIR;
+import static org.apache.hadoop.yarn.conf.YarnConfiguration.YARN_SITE_CONFIGURATION_FILE;
 
 
 /**
@@ -16,7 +18,6 @@ import play.Logger;
 public class Configuration {
   private static final Logger.ALogger LOG = Logger.of(Configuration.class);
 
-  private static final String HADOOP_CONF_DIR = ApplicationConstants.Environment.HADOOP_CONF_DIR.key();
   private static final String CORE_SITE_CONF = YarnConfiguration.CORE_SITE_CONFIGURATION_FILE;
   private static final String HDFS_SITE_CONF = "hdfs-site.xml";
 
@@ -25,16 +26,22 @@ public class Configuration {
 
   public Configuration() {
     hdfsConf = new HdfsConfiguration();
-    if (System.getenv("HADOOP_CONF_DIR") != null) {
-      hdfsConf.addResource(new Path(System.getenv(HADOOP_CONF_DIR) + File.separatorChar + CORE_SITE_CONF));
-      hdfsConf.addResource(new Path(System.getenv(HADOOP_CONF_DIR) + File.separatorChar + HDFS_SITE_CONF));
+    yarnConf = new YarnConfiguration();
+
+    String hadoopConfDir = System.getenv(HADOOP_CONF_DIR.key());
+    if (hadoopConfDir != null) {
+      Path coreSitePath = new Path(hadoopConfDir + File.separatorChar + CORE_SITE_CONF);
+
+      hdfsConf.addResource(coreSitePath);
+      hdfsConf.addResource(new Path(hadoopConfDir + File.separatorChar + HDFS_SITE_CONF));
+
+      yarnConf.addResource(coreSitePath);
+      yarnConf.addResource(new Path(hadoopConfDir + File.separatorChar + YARN_SITE_CONFIGURATION_FILE));
     }
 
     // return `kerberos` if on Kerberized cluster.
     // return `simple` if on unsecure cluster.
     LOG.info("Hadoop Auth Setting: " + hdfsConf.get("hadoop.security.authentication"));
-
-    yarnConf = new YarnConfiguration();
   }
 
   public HdfsConfiguration getHdfsConf() {

--- a/tony-history-server/app/views/main.scala.html
+++ b/tony-history-server/app/views/main.scala.html
@@ -14,7 +14,7 @@
     <section id="top">
         <div class="wrapper">
             <img class="resize" src='@routes.Assets.versioned("images/banner-logo.png")' alt="logo" />
-            <h1>Tony History Server</h1>
+            <h1>TonY History Server</h1>
         </div>
     </section>
     @content

--- a/tony-history-server/test/controllers/BrowserTest.java
+++ b/tony-history-server/test/controllers/BrowserTest.java
@@ -29,6 +29,6 @@ public class BrowserTest extends WithBrowser {
   @Test
   public void test() {
     browser.goTo("http://localhost:" + play.api.test.Helpers.testServerPort());
-    assertTrue(browser.pageSource().contains("Tony History Server"));
+    assertTrue(browser.pageSource().contains("TonY History Server"));
   }
 }


### PR DESCRIPTION
Previously, the `YarnConfiguration` was not loading the settings in `core-site.xml` and `yarn-site.xml`, so the default RM address of `0.0.0.0` was used. This PR adds loading of `core-site.xml` and `yarn-site.xml` so that the configured RM address is used.