### PR TITLE
Fix race condition where thread is interrupted while flush is in progress

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/TonyApplicationMaster.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyApplicationMaster.java
@@ -166,7 +166,7 @@ public class TonyApplicationMaster {
   /** Lifecycle control **/
   private long appTimeout;
 
-  private boolean clientSignalToStop = false; // client signal to stop
+  private volatile boolean clientSignalToStop = false; // client signal to stop
 
   /** HeartBeat monitor **/
   private final AbstractLivelinessMonitor<TonyTask> hbMonitor;
@@ -398,12 +398,6 @@ public class TonyApplicationMaster {
         .build();
     eventHandlerThread.stop(jobDir, metadata);
 
-    // Wait for eventHandlerThread to wrap up before exiting
-    try {
-      eventHandlerThread.join();
-    } catch (InterruptedException e) {
-      LOG.error("Failed to dump leftover events", e);
-    }
     return succeeded;
   }
 

--- a/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
@@ -720,6 +720,7 @@ public class TonyClient implements AutoCloseable {
         exitCode = client.start();
         if (client.amRpcClient != null) {
           client.amRpcClient.finishApplication();
+          LOG.info("Sent message to AM to stop.");
         }
       }
     } catch (ParseException | IOException | YarnException e) {

--- a/tony-core/src/main/java/com/linkedin/tony/events/EventHandler.java
+++ b/tony-core/src/main/java/com/linkedin/tony/events/EventHandler.java
@@ -94,11 +94,11 @@ public class EventHandler extends Thread {
     // If setupThread method fails to create inProgressHistFile,
     // return immediately since we don't have any file to begin with
     if (inProgressHistFile == null) {
-      LOG.info("inProgressHistFile is null");
+      LOG.warn("inProgressHistFile is null");
       return;
     }
 
-    while (!isStopped && !this.isInterrupted()) {
+    while (!isStopped && !Thread.currentThread().isInterrupted()) {
       writeEvent(eventQueue, dataFileWriter);
     }
 
@@ -127,9 +127,10 @@ public class EventHandler extends Thread {
 
   public void stop(Path intermDir, JobMetadata metadata) {
     if (inProgressHistFile == null) {
-      LOG.info("inProgressHistFile is null, in stop");
+      LOG.warn("inProgressHistFile is null");
       return;
     }
+
     finalHistFile = new Path(intermDir, HistoryFileUtils.generateFileName(metadata));
     LOG.info("Stopping event handler thread");
     isStopped = true;

--- a/tony-core/src/main/java/com/linkedin/tony/events/EventHandler.java
+++ b/tony-core/src/main/java/com/linkedin/tony/events/EventHandler.java
@@ -21,7 +21,9 @@ import org.apache.hadoop.fs.Path;
 
 public class EventHandler extends Thread {
   private static final Log LOG = LogFactory.getLog(EventHandler.class);
-  private boolean isStopped = false;
+
+  private volatile boolean isStopped = false;
+
   private BlockingQueue<Event> eventQueue;
   private Path finalHistFile = null;
   private Path inProgressHistFile = null;
@@ -60,12 +62,13 @@ public class EventHandler extends Thread {
     } catch (IOException e) {
       LOG.error("Failed to append event " + event, e);
     } catch (InterruptedException e) {
-      LOG.info("Event writer interrupted", e);
+      LOG.info("Event writer interrupted");
     }
   }
 
   @VisibleForTesting
   void drainQueue(BlockingQueue<Event> queue, DataFileWriter<Event> writer) {
+    LOG.info("Draining queue");
     while (!eventQueue.isEmpty()) {
       try {
         Event event = queue.poll();
@@ -78,6 +81,7 @@ public class EventHandler extends Thread {
 
   public void emitEvent(Event event) {
     try {
+      LOG.info("Emitting event: " + event);
       eventQueue.put(event);
     } catch (InterruptedException e) {
       LOG.error("Failed to add event " + event + " to event queue", e);
@@ -90,16 +94,19 @@ public class EventHandler extends Thread {
     // If setupThread method fails to create inProgressHistFile,
     // return immediately since we don't have any file to begin with
     if (inProgressHistFile == null) {
+      LOG.info("inProgressHistFile is null");
       return;
     }
 
-    while (!isStopped && !Thread.currentThread().isInterrupted()) {
+    while (!isStopped && !this.isInterrupted()) {
       writeEvent(eventQueue, dataFileWriter);
     }
 
     // Clear the queue
     drainQueue(eventQueue, dataFileWriter);
+  }
 
+  private void cleanUp() {
     try {
       dataFileWriter.close();
       if (out != null) {
@@ -108,13 +115,9 @@ public class EventHandler extends Thread {
     } catch (IOException e) {
       LOG.error("Failed to close writer", e);
     }
+  }
 
-    // At this point, finalHistFile should be set
-    // If not, then leave the inProgressHistFile as is.
-    if (finalHistFile == null) {
-      return;
-    }
-
+  private void moveInProgressToFinal() {
     try {
       myFs.rename(inProgressHistFile, finalHistFile);
     } catch (IOException e) {
@@ -124,12 +127,21 @@ public class EventHandler extends Thread {
 
   public void stop(Path intermDir, JobMetadata metadata) {
     if (inProgressHistFile == null) {
+      LOG.info("inProgressHistFile is null, in stop");
       return;
     }
-    isStopped = true;
-    LOG.info("Stopped event handler thread");
     finalHistFile = new Path(intermDir, HistoryFileUtils.generateFileName(metadata));
+    LOG.info("Stopping event handler thread");
+    isStopped = true;
     this.interrupt();
+    try {
+      this.join();
+    } catch (InterruptedException e) {
+      LOG.warn("Encountered interruption while stopping event handler thread", e);
+    }
+
+    cleanUp();
+    moveInProgressToFinal();
   }
 }
 


### PR DESCRIPTION
This PR fixes the race condition (see #157) by moving the `dataFileWriter.close()` call into the `stop()` method, after the event handler thread has terminated.