### PR TITLE
TonyClient should support reading conf_file, source program, and Python venv from remote filesystem #163

### DIFF
--- a/tony-cli/src/main/java/com/linkedin/tony/cli/ClusterSubmitter.java
+++ b/tony-cli/src/main/java/com/linkedin/tony/cli/ClusterSubmitter.java
@@ -59,14 +59,6 @@ public class ClusterSubmitter extends TonySubmitter {
       cachedLibPath = new Path(fs.getHomeDirectory(), TONY_FOLDER + Path.SEPARATOR + UUID.randomUUID().toString());
       LOG.info("Copying " + jarLocation + " to: " + cachedLibPath);
       fs.mkdirs(cachedLibPath);
-
-//      Path src = new Path(jarLocation);  // gs://  --> GsFileSystem, file:// --> local, /foo --> defaultFs
-//      FileSystem srcFs = src.getFileSystem(hdfsConf);
-//      Path dst = cachedLibPath;
-//      FileSystem dstFs = dst.getFileSystem(hdfsConf);
-//
-//      FileUtil.copy(srcFs, src, dstFs, dst, false, true, hdfsConf);
-
       fs.copyFromLocalFile(new Path(jarLocation), cachedLibPath);
 
       // Insert --hdfs_classpath at the beginning to avoid confusion when user pass in wrong arguments.

--- a/tony-cli/src/main/java/com/linkedin/tony/cli/ClusterSubmitter.java
+++ b/tony-cli/src/main/java/com/linkedin/tony/cli/ClusterSubmitter.java
@@ -20,6 +20,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
 import static com.linkedin.tony.Constants.*;
 
@@ -58,6 +59,14 @@ public class ClusterSubmitter extends TonySubmitter {
       cachedLibPath = new Path(fs.getHomeDirectory(), TONY_FOLDER + Path.SEPARATOR + UUID.randomUUID().toString());
       LOG.info("Copying " + jarLocation + " to: " + cachedLibPath);
       fs.mkdirs(cachedLibPath);
+
+//      Path src = new Path(jarLocation);  // gs://  --> GsFileSystem, file:// --> local, /foo --> defaultFs
+//      FileSystem srcFs = src.getFileSystem(hdfsConf);
+//      Path dst = cachedLibPath;
+//      FileSystem dstFs = dst.getFileSystem(hdfsConf);
+//
+//      FileUtil.copy(srcFs, src, dstFs, dst, false, true, hdfsConf);
+
       fs.copyFromLocalFile(new Path(jarLocation), cachedLibPath);
 
       // Insert --hdfs_classpath at the beginning to avoid confusion when user pass in wrong arguments.

--- a/tony-cli/src/main/java/com/linkedin/tony/cli/ClusterSubmitter.java
+++ b/tony-cli/src/main/java/com/linkedin/tony/cli/ClusterSubmitter.java
@@ -20,7 +20,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
 import static com.linkedin.tony.Constants.*;
 

--- a/tony-cli/src/main/java/com/linkedin/tony/cli/NotebookSubmitter.java
+++ b/tony-cli/src/main/java/com/linkedin/tony/cli/NotebookSubmitter.java
@@ -48,9 +48,6 @@ public class NotebookSubmitter extends TonySubmitter {
   private NotebookSubmitter() {
     this.client = new TonyClient(new Configuration());
   }
-  public NotebookSubmitter(TonyClient client) {
-    this.client = client;
-  }
 
   public int submit(String[] args) throws ParseException, URISyntaxException, IOException, InterruptedException {
     LOG.info("Starting NotebookSubmitter..");
@@ -99,9 +96,9 @@ public class NotebookSubmitter extends TonySubmitter {
             localSocket.close();
             ProxyServer server = new ProxyServer(hostPort[0], Integer.parseInt(hostPort[1]), localPort);
             LOG.info("If you are running NotebookSubmitter in your local box, please open [localhost:"
-                     + String.valueOf(localPort) + "] in your browser to visit the page. Otherwise, if "
+                     + localPort + "] in your browser to visit the page. Otherwise, if "
                      + "you're running NotebookSubmitter in a remote machine (like a gateway), please run"
-                     + " [ssh -L 18888:localhost:" + String.valueOf(localPort)
+                     + " [ssh -L 18888:localhost:" + localPort
                      + " name_of_this_host] in your laptop and open [localhost:18888] in your browser to "
                      + "visit Jupyter Notebook. If the 18888 port is occupied, replace that number with another number.");
             server.start();

--- a/tony-core/src/main/java/com/linkedin/tony/TonyApplicationMaster.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyApplicationMaster.java
@@ -1096,19 +1096,11 @@ public class TonyApplicationMaster {
       // Add job type specific resources
       Map<String, LocalResource> containerResources = new ConcurrentHashMap<>(localResources);
       String[] resources = tonyConf.getStrings(TonyConfigurationKeys.getResourcesKey(task.getJobName()));
-      if (null != resources) {
-        for (String dir : resources) {
-          Utils.addResource(dir, containerResources, resourceFs);
-        }
-      }
+      Utils.addResources(resources, containerResources, resourceFs);
 
       // All resources available to all containers
       resources = tonyConf.getStrings(TonyConfigurationKeys.getContainerResourcesKey());
-      if (null != resources) {
-        for (String dir : resources) {
-          Utils.addResource(dir, containerResources, resourceFs);
-        }
-      }
+      Utils.addResources(resources, containerResources, resourceFs);
 
       task.addContainer(container);
       LOG.info("Setting Container [" + container.getId() + "] for task [" + task.getId() + "]..");

--- a/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
@@ -367,7 +367,7 @@ public class TonyClient implements AutoCloseable {
         tonyConf.addResource(confFilePath.getFileSystem(hdfsConf).open(confFilePath));
       }
     } else {
-      // Searched for on the classpath. Will NOT throw an error if not present on classpath.
+      // Search for tony.xml on classpath. Will NOT throw an error if not present on classpath.
       tonyConf.addResource(Constants.TONY_XML);
     }
     if (cliParser.hasOption("conf")) {

--- a/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
@@ -11,6 +11,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.linkedin.tony.rpc.TaskUrl;
 import com.linkedin.tony.rpc.impl.ApplicationRpcClient;
+import com.linkedin.tony.util.HdfsUtils;
 import com.linkedin.tony.util.Utils;
 import com.linkedin.tony.util.VersionInfo;
 import java.io.File;
@@ -34,7 +35,6 @@ import org.apache.commons.cli.GnuParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -208,7 +208,7 @@ public class TonyClient implements AutoCloseable {
 
     // Set the ContainerLaunchContext to describe the Container ith which the TonyApplicationMaster is launched.
     ContainerLaunchContext amSpec =
-        createAMContainerSpec(appId, this.amMemory, this.taskParams, this.pythonBinaryPath, this.executes, getTokens());
+        createAMContainerSpec(this.amMemory, this.taskParams, this.pythonBinaryPath, this.executes, getTokens());
     appContext.setAMContainerSpec(amSpec);
     String nodeLabel = tonyConf.get(TonyConfigurationKeys.APPLICATION_NODE_LABEL);
     if (nodeLabel != null) {
@@ -262,7 +262,7 @@ public class TonyClient implements AutoCloseable {
     new HelpFormatter().printHelp("TonyClient", opts);
   }
 
-  public boolean init(String[] args) throws ParseException {
+  public boolean init(String[] args) throws ParseException, IOException {
     CommandLine cliParser = new GnuParser().parse(opts, args, true);
     if (args.length == 0) {
       throw new IllegalArgumentException("No args specified for client to initialize");
@@ -315,8 +315,6 @@ public class TonyClient implements AutoCloseable {
                                          + " Specified virtual cores=" + amVCores);
     }
 
-    int numWorkers = tonyConf.getInt(TonyConfigurationKeys.getInstancesKey(Constants.WORKER_JOB_NAME),
-        TonyConfigurationKeys.getDefaultInstances(Constants.WORKER_JOB_NAME));
     boolean singleNode = tonyConf.getBoolean(TonyConfigurationKeys.IS_SINGLE_NODE,
         TonyConfigurationKeys.DEFAULT_IS_SINGLE_NODE);
     if (!singleNode) {
@@ -357,11 +355,19 @@ public class TonyClient implements AutoCloseable {
    * @param tonyConf Configuration object.
    * @param cliParser CommandLine object that has all the command line arguments.
    */
-  public static void initTonyConf(Configuration tonyConf, CommandLine cliParser) {
+  public void initTonyConf(Configuration tonyConf, CommandLine cliParser) throws IOException {
     tonyConf.addResource(Constants.TONY_DEFAULT_XML);
     if (cliParser.hasOption("conf_file")) {
-      tonyConf.addResource(new Path(cliParser.getOptionValue("conf_file")));
+      Path confFilePath = new Path(cliParser.getOptionValue("conf_file"));
+
+      // if no scheme, assume local file, else read using corresponding filesystem
+      if (confFilePath.toUri().getScheme() == null) {
+        tonyConf.addResource(confFilePath);
+      } else {
+        tonyConf.addResource(confFilePath.getFileSystem(hdfsConf).open(confFilePath));
+      }
     } else {
+      // Searched for on the classpath. Will NOT throw an error if not present on classpath.
       tonyConf.addResource(Constants.TONY_XML);
     }
     if (cliParser.hasOption("conf")) {
@@ -382,26 +388,22 @@ public class TonyClient implements AutoCloseable {
     return this.tonyConf;
   }
 
-  public ContainerLaunchContext createAMContainerSpec(ApplicationId appId, long amMemory, String taskParams,
+  public ContainerLaunchContext createAMContainerSpec(long amMemory, String taskParams,
                                                       String pythonBinaryPath, String executes,
                                                       ByteBuffer tokens) throws IOException {
     ContainerLaunchContext amContainer = Records.newRecord(ContainerLaunchContext.class);
 
     FileSystem fs = FileSystem.get(hdfsConf);
     Map<String, LocalResource> localResources = new HashMap<>();
-    addLocalResources(fs, tonyFinalConfPath, LocalResourceType.FILE, Constants.TONY_FINAL_XML, localResources);
+    addResource(fs, tonyFinalConfPath, LocalResourceType.FILE, Constants.TONY_FINAL_XML, localResources);
+
+    // Add AM resources
     String[] amResources = tonyConf.getStrings(TonyConfigurationKeys.getResourcesKey(Constants.AM_NAME));
-    if (null != amResources) {
-      for (String dir : amResources) {
-        Utils.addResource(dir, localResources, fs);
-      }
-    }
+    Utils.addResources(amResources, localResources, fs);
+
+    // Add resources for all containers
     amResources = tonyConf.getStrings(TonyConfigurationKeys.getContainerResourcesKey());
-    if (null != amResources) {
-      for (String dir : amResources) {
-        Utils.addResource(dir, localResources, fs);
-      }
-    }
+    Utils.addResources(amResources, localResources, fs);
 
     setAMEnvironment(localResources, fs);
 
@@ -440,13 +442,13 @@ public class TonyClient implements AutoCloseable {
     arguments.add("com.linkedin.tony.TonyApplicationMaster");
 
     if (taskParams != null) {
-      arguments.add("--task_params " + "'" + String.valueOf(taskParams) + "'");
+      arguments.add("--task_params " + "'" + taskParams + "'");
     }
     if (pythonBinaryPath != null) {
-      arguments.add("--python_binary_path " + String.valueOf(pythonBinaryPath));
+      arguments.add("--python_binary_path " + pythonBinaryPath);
     }
     if (executes != null) {
-      arguments.add("--executes " + String.valueOf(executes));
+      arguments.add("--executes " + executes);
     }
     for (Map.Entry<String, String> entry : shellEnv.entrySet()) {
       arguments.add("--shell_env " + entry.getKey() + "=" + entry.getValue());
@@ -460,17 +462,19 @@ public class TonyClient implements AutoCloseable {
   }
 
   /**
-   * Add a local resource to HDFS and local resources map.
+   * Adds resource to HDFS and local resources map.
    * @param fs HDFS file system reference
+   * @param srcPath Source path of resource. If no scheme is included, assumed to be on local filesystem.
    * @param resourceType the type of the src file
    * @param dstPath name of the resource after localization
    * @param localResources the local resources map
    * @throws IOException error when writing to HDFS
    */
-  private void addLocalResources(FileSystem fs, String srcPath, LocalResourceType resourceType,
+  private void addResource(FileSystem fs, String srcPath, LocalResourceType resourceType,
                                  String dstPath, Map<String, LocalResource> localResources) throws IOException {
+    Path src = new Path(srcPath);
     Path dst = new Path(appResourcesPath, dstPath);
-    fs.copyFromLocalFile(new Path(srcPath), dst);
+    HdfsUtils.copySrcToDest(src, dst, hdfsConf);
     fs.setPermission(dst, new FsPermission((short) 0770));
     FileStatus scFileStatus = fs.getFileStatus(dst);
     LocalResource scRsrc =
@@ -578,7 +582,7 @@ public class TonyClient implements AutoCloseable {
    * Kill application if time expires.
    * @param appId Application Id of application to be monitored
    * @return true if application completed successfully
-   * @throws org.apache.hadoop.yarn.exceptions.YarnException
+   * @throws YarnException
    * @throws java.io.IOException
    */
   private boolean monitorApplication(ApplicationId appId)
@@ -649,27 +653,22 @@ public class TonyClient implements AutoCloseable {
   }
 
   private void uploadFileAndSetConfResources(Path hdfsPath, Path filePath,
-      Configuration tonyConf, FileSystem fs) throws IOException {
-    uploadFileAndSetConfResources(hdfsPath, filePath, filePath.getName(), tonyConf, fs);
-  }
-
-  private void uploadFileAndSetConfResources(Path hdfsPath, Path filePath,
       String fileName, Configuration tonyConf, FileSystem fs) throws IOException {
     Path dst = new Path(hdfsPath, fileName);
-    fs.copyFromLocalFile(filePath, dst);
+    HdfsUtils.copySrcToDest(filePath, dst, tonyConf);
     fs.setPermission(dst, new FsPermission((short) 0770));
     appendConfResources(TonyConfigurationKeys.getContainerResourcesKey(), dst.toString(), tonyConf);
   }
 
   private void appendConfResources(String key, String resource, Configuration tonyConf) {
     String currentResources = tonyConf.get(key, "");
-    tonyConf.set(TonyConfigurationKeys.getContainerResourcesKey(), currentResources + "," + resource);
+    tonyConf.set(key, currentResources + "," + resource);
   }
 
   /**
    * Kill a submitted application by sending a call to the ASM
    * @param appId Application Id to be killed.
-   * @throws org.apache.hadoop.yarn.exceptions.YarnException
+   * @throws YarnException
    * @throws java.io.IOException
    */
   private void forceKillApplication(ApplicationId appId)

--- a/tony-core/src/main/java/com/linkedin/tony/tensorflow/TonySession.java
+++ b/tony-core/src/main/java/com/linkedin/tony/tensorflow/TonySession.java
@@ -134,15 +134,7 @@ public class TonySession {
     try {
       if (hdfsClasspathDir != null) {
         FileSystem fs = FileSystem.get(new URI(hdfsClasspathDir), hdfsConf);
-        FileStatus[] ls = fs.listStatus(new Path(hdfsClasspathDir));
-        for (FileStatus jar : ls) {
-          LocalResource resource =
-              LocalResource.newInstance(ConverterUtils.getYarnUrlFromURI(URI.create(jar.getPath().toString())),
-                                        LocalResourceType.FILE, LocalResourceVisibility.PRIVATE,
-                                        jar.getLen(), jar.getModificationTime());
-
-          localResources.put(jar.getPath().getName(), resource);
-        }
+        Utils.addResource(hdfsClasspathDir, localResources, fs);
       }
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/tony-core/src/main/java/com/linkedin/tony/util/HdfsUtils.java
+++ b/tony-core/src/main/java/com/linkedin/tony/util/HdfsUtils.java
@@ -15,9 +15,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
 
 
@@ -138,6 +140,24 @@ public class HdfsUtils {
       LOG.error("Failed to traverse down history folder", e);
     }
     return intermediateFolders;
+  }
+
+  /**
+   * Copies {@code src} to {@code dst}. If {@code src} does not have a scheme, it is assumed to be on local filesystem.
+   * @param src  Source {@code Path}
+   * @param dst  Destination {@code Path}
+   * @param conf  HDFS configuration
+   * @throws IOException
+   */
+  public static void copySrcToDest(Path src, Path dst, Configuration conf) throws IOException {
+    FileSystem srcFs;
+    if (src.toUri().getScheme() == null) {
+      srcFs = FileSystem.getLocal(conf);
+    } else {
+      srcFs = src.getFileSystem(conf);
+    }
+    FileSystem dstFs = dst.getFileSystem(conf);
+    FileUtil.copy(srcFs, src, dstFs, dst, false, true, conf);
   }
 
   private HdfsUtils() { }

--- a/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
+++ b/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
@@ -407,24 +407,40 @@ public class Utils {
   }
 
   /**
+   * Adds the resources in {@code resources} to the {@code resourcesMap}.
+   * @param resources  List of resource paths to process. If a resource is a directory,
+   *                   its immediate files will be added.
+   * @param resourcesMap  map where resource path to {@Link LocalResource} mapping will be added
+   * @param fs  {@link FileSystem} used to list the resources
+   */
+  public static void addResources(String[] resources, Map<String, LocalResource> resourcesMap, FileSystem fs) {
+    if (null != resources) {
+      for (String dir : resources) {
+        Utils.addResource(dir, resourcesMap, fs);
+      }
+    }
+  }
+
+  /**
    * Add files inside a path to local resources. If the path is a directory, its first level files will be added
    * to the local resources. Note that we don't add nested files.
    * @param path the directory whose contents will be localized.
+   * @param resourcesMap map where resource path to {@link LocalResource} mapping will be added
    * @param fs the filesystem instance used to read the {@code path}.
    */
   public static void addResource(String path, Map<String, LocalResource> resourcesMap, FileSystem fs) {
     try {
       if (path != null) {
         FileStatus[] ls = fs.listStatus(new Path(path));
-        for (FileStatus jar : ls) {
+        for (FileStatus fileStatus : ls) {
           // We only add first level files.
-          if (jar.isDirectory()) {
+          if (fileStatus.isDirectory()) {
             continue;
           }
-          LocalResource resource = LocalResource.newInstance(ConverterUtils.getYarnUrlFromURI(URI.create(jar.getPath().toString())),
+          LocalResource resource = LocalResource.newInstance(ConverterUtils.getYarnUrlFromURI(URI.create(fileStatus.getPath().toString())),
                                                              LocalResourceType.FILE, LocalResourceVisibility.PRIVATE,
-                                                             jar.getLen(), jar.getModificationTime());
-          resourcesMap.put(jar.getPath().getName(), resource);
+                                                             fileStatus.getLen(), fileStatus.getModificationTime());
+          resourcesMap.put(fileStatus.getPath().getName(), resource);
         }
       }
     } catch (IOException exception) {

--- a/tony-core/src/test/java/com/linkedin/tony/TestTonyE2E.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestTonyE2E.java
@@ -7,6 +7,7 @@ package com.linkedin.tony;
 import com.linkedin.minitony.cluster.HDFSUtils;
 import com.linkedin.minitony.cluster.MiniCluster;
 import com.linkedin.minitony.cluster.MiniTonyUtils;
+import java.io.IOException;
 import java.nio.file.Files;
 import org.apache.commons.cli.ParseException;
 import org.apache.hadoop.conf.Configuration;
@@ -71,7 +72,7 @@ public class TestTonyE2E {
   }
 
   @Test
-  public void testSingleNodeTrainingShouldPass() throws ParseException {
+  public void testSingleNodeTrainingShouldPass() throws ParseException, IOException {
     conf.setBoolean(TonyConfigurationKeys.IS_SINGLE_NODE, true);
     client = new TonyClient(conf);
     client.init(new String[] {
@@ -87,7 +88,7 @@ public class TestTonyE2E {
   }
 
   @Test
-  public void testPSWorkerTrainingShouldFailMissedHeartbeat() throws ParseException {
+  public void testPSWorkerTrainingShouldFailMissedHeartbeat() throws ParseException, IOException {
     conf.setBoolean(TonyConfigurationKeys.SECURITY_ENABLED, false);
     conf.setInt(TonyConfigurationKeys.TASK_MAX_MISSED_HEARTBEATS, 2);
     client = new TonyClient(conf);
@@ -104,7 +105,7 @@ public class TestTonyE2E {
   }
 
   @Test
-  public void testPSSkewedWorkerTrainingShouldPass() throws ParseException {
+  public void testPSSkewedWorkerTrainingShouldPass() throws ParseException, IOException {
     conf.setInt(TonyConfigurationKeys.getInstancesKey("worker"), 2);
     client = new TonyClient(conf);
     client.init(new String[]{
@@ -121,7 +122,7 @@ public class TestTonyE2E {
   }
 
   @Test
-  public void testPSWorkerTrainingShouldPass() throws ParseException {
+  public void testPSWorkerTrainingShouldPass() throws ParseException, IOException {
     client.init(new String[]{
         "--src_dir", "tony-core/src/test/resources/",
         "--executes", "'python check_env_and_venv.py'",
@@ -135,7 +136,7 @@ public class TestTonyE2E {
   }
 
   @Test
-  public void testPSWorkerTrainingPyTorchShouldPass() throws ParseException {
+  public void testPSWorkerTrainingPyTorchShouldPass() throws ParseException, IOException {
     client.init(new String[]{
         "--src_dir", "tony-core/src/test/resources/",
         "--executes", "exit_0_check_pytorchenv.py",
@@ -152,7 +153,7 @@ public class TestTonyE2E {
   }
 
   @Test
-  public void testPSWorkerTrainingShouldFail() throws ParseException {
+  public void testPSWorkerTrainingShouldFail() throws ParseException, IOException {
     client.init(new String[]{
         "--src_dir", "tony-core/src/test/resources/",
         "--executes", "exit_1.py",
@@ -165,7 +166,7 @@ public class TestTonyE2E {
   }
 
   @Test
-  public void testSingleNodeTrainingShouldFail() throws ParseException {
+  public void testSingleNodeTrainingShouldFail() throws ParseException, IOException {
     conf.setBoolean(TonyConfigurationKeys.IS_SINGLE_NODE, true);
     client = new TonyClient(conf);
     client.init(new String[]{
@@ -180,7 +181,7 @@ public class TestTonyE2E {
   }
 
   @Test
-  public void testAMCrashTonyShouldFail() throws ParseException {
+  public void testAMCrashTonyShouldFail() throws ParseException, IOException {
     conf.setBoolean(TonyConfigurationKeys.IS_SINGLE_NODE, true);
     client = new TonyClient(conf);
     client.init(new String[]{
@@ -203,7 +204,7 @@ public class TestTonyE2E {
    * allocated is that Physical Memory Enforcement doesn't seem to work under MiniYARN.
    */
   @Test
-  public void testAMStopsJobAfterWorker0Killed() throws ParseException {
+  public void testAMStopsJobAfterWorker0Killed() throws ParseException, IOException {
     client.init(new String[]{"--src_dir", "tony-core/src/test/resources/", "--executes", "exit_0.py", "--hdfs_classpath", "/yarn/libs", "--python_binary_path", "python", "--container_env",
         Constants.TEST_WORKER_TERMINATED + "=true"});
     int exitCode = client.start();
@@ -214,7 +215,7 @@ public class TestTonyE2E {
    * Test amRpcClient is nulled out after client finishes.
    */
   @Test
-  public void testNullAMRpcClient() throws ParseException {
+  public void testNullAMRpcClient() throws ParseException, IOException {
     String[] args = new String[]{
         "--src_dir", "tony-core/src/test/resources/",
         "--executes", "exit_0.py",
@@ -227,7 +228,7 @@ public class TestTonyE2E {
   }
 
   @Test
-  public void testNonChiefWorkerFail() throws ParseException {
+  public void testNonChiefWorkerFail() throws ParseException, IOException {
     conf.setBoolean(TonyConfigurationKeys.IS_SINGLE_NODE, false);
     client = new TonyClient(conf);
     client.init(new String[]{
@@ -242,7 +243,7 @@ public class TestTonyE2E {
   }
 
   @Test
-  public void testTonyResourcesFlag() throws ParseException {
+  public void testTonyResourcesFlag() throws ParseException, IOException {
     conf.setBoolean(TonyConfigurationKeys.IS_SINGLE_NODE, false);
     client = new TonyClient(conf);
     client.init(new String[]{
@@ -257,7 +258,7 @@ public class TestTonyE2E {
   }
 
   @Test
-  public void testTensorBoardPortSetOnlyOnChiefWorker() throws ParseException {
+  public void testTensorBoardPortSetOnlyOnChiefWorker() throws ParseException, IOException {
     client = new TonyClient(conf);
     client.init(new String[]{
         "--src_dir", "tony-core/src/test/resources/",


### PR DESCRIPTION
Tested reading conf_file, source program, and Python venv from HDFS:

```
java -cp $HOME/lib/tony-cli-0.1.5-all.jar:`hadoop classpath` com.linkedin.tony.cli.ClusterSubmitter \
--conf tony.containers.resources=hdfs:///user/ahsu/src/mnist_distributed.py \
--executes mnist_distributed.py \
--task_params='--data_dir hdfs://default/user/ahsu/data/mnist/zip --working_dir hdfs://default/tmp/ahsu-mnist' \
--conf_file=hdfs:///user/ahsu/config/tony.xml \
--python_venv=hdfs:///user/ahsu/lib/my_venv.zip \
--python_binary_path=Python/bin/python3
```

Note how `conf_file`, the source program (specified in `tony.containers.resources`), and `python_venv` are all on a remote filesystem.

@gogasca FYI.