### PR TITLE
LIHADOOP-43781: TonY should support enforcing maximum total number of tasks

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
@@ -11,6 +11,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.linkedin.tony.rpc.TaskUrl;
 import com.linkedin.tony.rpc.impl.ApplicationRpcClient;
+import com.linkedin.tony.tensorflow.TensorFlowContainerRequest;
 import com.linkedin.tony.util.HdfsUtils;
 import com.linkedin.tony.util.Utils;
 import com.linkedin.tony.util.VersionInfo;
@@ -386,19 +387,31 @@ public class TonyClient implements AutoCloseable {
   }
 
   /**
-   * Throws a {@link RuntimeException} if the configuration requests for more tasks than the max configured.
+   * Validates that the configuration does not request more task instances than allowed for a given task type
+   * or more than the max total instances allowed across all task types. Throws a {@link RuntimeException}
+   * if any limits are exceeded.
    * @param tonyConf  the configuration to validate
    */
   @VisibleForTesting
   static void validateTonyConf(Configuration tonyConf) {
-    int maxTasks = tonyConf.getInt(TonyConfigurationKeys.TONY_MAX_TASKS, -1);
-    if (maxTasks >= 0) {
-      int numRequestedTasks = Utils.parseContainerRequests(tonyConf).values().stream()
-          .mapToInt(containerReq -> containerReq.getNumInstances()).sum();
-      if (numRequestedTasks > maxTasks) {
-        throw new RuntimeException("Job requested " + numRequestedTasks + " total tasks but limit is " + maxTasks
-            + ".");
+    Map<String, TensorFlowContainerRequest> containerRequestMap = Utils.parseContainerRequests(tonyConf);
+
+    // check that we don't request more than the max allowed for any task type
+    for (Map.Entry<String, TensorFlowContainerRequest> entry : containerRequestMap.entrySet()) {
+      int numInstancesRequested = entry.getValue().getNumInstances();
+      int maxAllowedInstances = tonyConf.getInt(TonyConfigurationKeys.getMaxInstancesKey(entry.getKey()), -1);
+      if (maxAllowedInstances >= 0 && numInstancesRequested > maxAllowedInstances) {
+        throw new RuntimeException("Job requested " + numInstancesRequested + " " + entry.getKey() + " task instances "
+            + "but the limit is " + maxAllowedInstances + " " + entry.getKey() + " task instances.");
       }
+    }
+
+    // check that we don't request more than the allowed total tasks
+    int maxTotalInstances = tonyConf.getInt(TonyConfigurationKeys.TONY_MAX_TOTAL_INSTANCES, -1);
+    int totalRequestedInstances = containerRequestMap.values().stream().mapToInt(req -> req.getNumInstances()).sum();
+    if (maxTotalInstances >= 0 && totalRequestedInstances > maxTotalInstances) {
+      throw new RuntimeException("Job requested " + totalRequestedInstances + " total task instances but limit is "
+          + maxTotalInstances + ".");
     }
   }
 

--- a/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
@@ -108,6 +108,11 @@ public class TonyConfigurationKeys {
   // Task configurations
   public static final String TONY_TASK_PREFIX = TONY_PREFIX + "task.";
 
+  /**
+   * Max number of tasks that can be requested across all tony.X.instances configs.
+   */
+  public static final String TONY_MAX_TASKS = TONY_PREFIX + "max-tasks";
+
   public static final String TASK_EXECUTOR_JVM_OPTS = TONY_TASK_PREFIX + "executor.jvm.opts";
   public static final String DEFAULT_TASK_EXECUTOR_JVM_OPTS = "-Xmx1536m";
 

--- a/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
@@ -111,7 +111,7 @@ public class TonyConfigurationKeys {
   /**
    * Max number of tasks that can be requested across all tony.X.instances configs.
    */
-  public static final String TONY_MAX_TASKS = TONY_PREFIX + "max-tasks";
+  public static final String TONY_MAX_TASKS = TONY_TASK_PREFIX + "max-tasks";
 
   public static final String TASK_EXECUTOR_JVM_OPTS = TONY_TASK_PREFIX + "executor.jvm.opts";
   public static final String DEFAULT_TASK_EXECUTOR_JVM_OPTS = "-Xmx1536m";

--- a/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
@@ -147,6 +147,11 @@ public class TonyConfigurationKeys {
     return String.format(TONY_PREFIX + "%s.instances", jobName);
   }
 
+  /**
+   * Configuration key for property controlling how many {@code jobName} task instances a job can request.
+   * @param jobName the task type for which to get the max instances config key
+   * @return the max instances configuration key for the {@code jobName}
+   */
   public static String getMaxInstancesKey(String jobName) {
     return String.format(TONY_PREFIX + "%s.max-instances", jobName);
   }

--- a/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
@@ -109,9 +109,9 @@ public class TonyConfigurationKeys {
   public static final String TONY_TASK_PREFIX = TONY_PREFIX + "task.";
 
   /**
-   * Max number of tasks that can be requested across all tony.X.instances configs.
+   * Max total number of task instances that can be requested across all task types.
    */
-  public static final String TONY_MAX_TASKS = TONY_TASK_PREFIX + "max-tasks";
+  public static final String TONY_MAX_TOTAL_INSTANCES = TONY_TASK_PREFIX + "max-total-instances";
 
   public static final String TASK_EXECUTOR_JVM_OPTS = TONY_TASK_PREFIX + "executor.jvm.opts";
   public static final String DEFAULT_TASK_EXECUTOR_JVM_OPTS = "-Xmx1536m";
@@ -147,6 +147,10 @@ public class TonyConfigurationKeys {
     return String.format(TONY_PREFIX + "%s.instances", jobName);
   }
 
+  public static String getMaxInstancesKey(String jobName) {
+    return String.format(TONY_PREFIX + "%s.max-instances", jobName);
+  }
+
   public static int getDefaultInstances(String jobName) {
     switch (jobName) {
       case Constants.PS_JOB_NAME:
@@ -156,6 +160,7 @@ public class TonyConfigurationKeys {
         return 0;
     }
   }
+
   public static String getMemoryKey(String jobName) {
     return String.format(TONY_PREFIX + "%s.memory", jobName);
   }

--- a/tony-core/src/main/resources/tony-default.xml
+++ b/tony-core/src/main/resources/tony-default.xml
@@ -66,7 +66,7 @@
 
   <!-- Task configurations -->
   <property>
-    <name>tony.task.max-tasks</name>
+    <name>tony.task.max-total-instances</name>
     <value>-1</value>
     <description>Maximum number of tasks that can be requested across all tony.X.instances configs.</description>
   </property>

--- a/tony-core/src/main/resources/tony-default.xml
+++ b/tony-core/src/main/resources/tony-default.xml
@@ -66,6 +66,12 @@
 
   <!-- Task configurations -->
   <property>
+    <name>tony.task.max-tasks</name>
+    <value>-1</value>
+    <description>Maximum number of tasks that can be requested across all tony.X.instances configs.</description>
+  </property>
+
+  <property>
     <description>JVM opts for each TaskExecutor.</description>
     <name>tony.task.executor.jvm.opts</name>
     <value>-Xmx1536m</value>

--- a/tony-core/src/test/java/com/linkedin/tony/TestTonyClient.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestTonyClient.java
@@ -5,6 +5,7 @@
 package com.linkedin.tony;
 
 import java.util.HashMap;
+import org.apache.hadoop.conf.Configuration;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -27,5 +28,22 @@ public class TestTonyClient {
         + "TonyApplicationMaster --python_binary_path venv/python --executes ls"
         + " 1><LOG_DIR>/amstdout.log 2><LOG_DIR>/amstderr.log";
     assertEquals(command, expected);
+  }
+
+  @Test
+  public void testValidateTonyConfValidConf() {
+    Configuration conf = new Configuration();
+    conf.setInt("tony.foo.instances", 2);
+    conf.setInt("tony.bar.instances", 2);
+    TonyClient.validateTonyConf(conf);
+  }
+
+  @Test(expectedExceptions = RuntimeException.class)
+  public void testValidateTonyConfTooManyInstances() {
+    Configuration conf = new Configuration();
+    conf.setInt(TonyConfigurationKeys.TONY_MAX_TASKS, 3);
+    conf.setInt("tony.foo.instances", 2);
+    conf.setInt("tony.bar.instances", 2);
+    TonyClient.validateTonyConf(conf);
   }
 }

--- a/tony-core/src/test/java/com/linkedin/tony/TestTonyClient.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestTonyClient.java
@@ -38,19 +38,27 @@ public class TestTonyClient {
     TonyClient.validateTonyConf(conf);
   }
 
-  @Test(expectedExceptions = RuntimeException.class)
-  public void testValidateTonyConfTooManyInstances() {
+  @Test
+  public void testValidateTonyConfZeroInstances() {
     Configuration conf = new Configuration();
-    conf.setInt(TonyConfigurationKeys.TONY_MAX_TASKS, 3);
+    conf.setInt(TonyConfigurationKeys.TONY_MAX_TOTAL_INSTANCES, 0);
+    TonyClient.validateTonyConf(conf);
+  }
+
+  @Test(expectedExceptions = RuntimeException.class)
+  public void testValidateTonyConfTooManyTotalInstances() {
+    Configuration conf = new Configuration();
+    conf.setInt(TonyConfigurationKeys.TONY_MAX_TOTAL_INSTANCES, 3);
     conf.setInt("tony.foo.instances", 2);
     conf.setInt("tony.bar.instances", 2);
     TonyClient.validateTonyConf(conf);
   }
 
-  @Test
-  public void testValidateTonyConfZeroInstances() {
+  @Test(expectedExceptions = RuntimeException.class)
+  public void testValidateTonyConfTooManyFooInstances() {
     Configuration conf = new Configuration();
-    conf.setInt(TonyConfigurationKeys.TONY_MAX_TASKS, 0);
+    conf.setInt(TonyConfigurationKeys.getMaxInstancesKey("foo"), 1);
+    conf.setInt("tony.foo.instances", 2);
     TonyClient.validateTonyConf(conf);
   }
 }

--- a/tony-core/src/test/java/com/linkedin/tony/TestTonyClient.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestTonyClient.java
@@ -46,4 +46,11 @@ public class TestTonyClient {
     conf.setInt("tony.bar.instances", 2);
     TonyClient.validateTonyConf(conf);
   }
+
+  @Test
+  public void testValidateTonyConfZeroInstances() {
+    Configuration conf = new Configuration();
+    conf.setInt(TonyConfigurationKeys.TONY_MAX_TASKS, 0);
+    TonyClient.validateTonyConf(conf);
+  }
 }


### PR DESCRIPTION
Addresses #169.

* Added `tony.X.max-instances` and `tony.task.max-total-instances` configs that allow limiting the number of X instances or total task instances a job can request.
* Added validation in TonyClient that enforces the limits and to throws a `RuntimeException` if violated
* Added unit tests