### PR TITLE
Fix "Rename TensorFlowJob to TonyJob #173"

### DIFF
--- a/tony-azkaban/src/main/java/com/linkedin/tony/azkaban/TonyJob.java
+++ b/tony-azkaban/src/main/java/com/linkedin/tony/azkaban/TonyJob.java
@@ -122,9 +122,9 @@ public class TonyJob extends HadoopJavaJob {
     }
 
     Map<String, String> tonyConfs = getJobProps().getMapByPrefix(TONY_CONF_PREFIX);
-    Configuration tfConf = new Configuration(false);
-    for (Map.Entry<String, String> tfConfEntry : tonyConfs.entrySet()) {
-      tfConf.set(TONY_CONF_PREFIX + tfConfEntry.getKey(), tfConfEntry.getValue());
+    Configuration tonyConf = new Configuration(false);
+    for (Map.Entry<String, String> confEntry : tonyConfs.entrySet()) {
+      tonyConf.set(TONY_CONF_PREFIX + confEntry.getKey(), confEntry.getValue());
     }
 
     // Write user's tony confs to an xml to be localized.
@@ -134,7 +134,7 @@ public class TonyJob extends HadoopJavaJob {
           + " for TonY conf file.");
     }
     try (OutputStream os = new FileOutputStream(tonyConfFile)) {
-      tfConf.writeXml(os);
+      tonyConf.writeXml(os);
     } catch (Exception e) {
       throw new RuntimeException("Failed to create " + tonyXml + " conf file. Exiting.", e);
     }

--- a/tony-azkaban/src/main/java/com/linkedin/tony/azkaban/TonyJob.java
+++ b/tony-azkaban/src/main/java/com/linkedin/tony/azkaban/TonyJob.java
@@ -17,11 +17,11 @@ import org.apache.log4j.Logger;
 
 
 /**
- * The Azkaban jobtype for running a TensorFlow job.
+ * The Azkaban jobtype for running a TonY job.
  * This class is used by Azkaban executor to build the classpath, main args,
  * env and jvm properties.
  */
-public class TensorFlowJob extends HadoopJavaJob {
+public class TonyJob extends HadoopJavaJob {
   public static final String HADOOP_OPTS = ENV_PREFIX + "HADOOP_OPTS";
   public static final String HADOOP_GLOBAL_OPTS = "hadoop.global.opts";
   public static final String WORKER_ENV_PREFIX = "worker_env.";
@@ -29,7 +29,7 @@ public class TensorFlowJob extends HadoopJavaJob {
   private String tonyXml;
   private File tonyConfFile;
 
-  public TensorFlowJob(String jobid, Props sysProps, Props jobProps, Logger log) {
+  public TonyJob(String jobid, Props sysProps, Props jobProps, Logger log) {
     super(jobid, sysProps, jobProps, log);
 
     tonyXml = String.format("_tony-conf-%s/tony.xml", jobid);
@@ -45,7 +45,7 @@ public class TensorFlowJob extends HadoopJavaJob {
 
   @Override
   public void run() throws Exception {
-    getLog().info("Hello world from TensorFlow!");
+    getLog().info("Running TonY job!");
     setupHadoopOpts(getJobProps());
     super.run();
   }
@@ -87,38 +87,38 @@ public class TensorFlowJob extends HadoopJavaJob {
     StringBuilder args = new StringBuilder(super.getMainArguments());
     info("All job props: " + getJobProps());
     info("All sys props: " + getSysProps());
-    String srcDir = getJobProps().getString(TensorFlowJobArg.SRC_DIR.azPropName, "src");
-    args.append(" " + TensorFlowJobArg.SRC_DIR.tonyParamName + " " + srcDir);
+    String srcDir = getJobProps().getString(TonyJobArg.SRC_DIR.azPropName, "src");
+    args.append(" " + TonyJobArg.SRC_DIR.tonyParamName + " " + srcDir);
 
-    String hdfsClasspath = getJobProps().getString(TensorFlowJobArg.HDFS_CLASSPATH.azPropName, null);
+    String hdfsClasspath = getJobProps().getString(TonyJobArg.HDFS_CLASSPATH.azPropName, null);
     if (hdfsClasspath != null) {
-      args.append(" " + TensorFlowJobArg.HDFS_CLASSPATH.tonyParamName + " " + hdfsClasspath);
+      args.append(" " + TonyJobArg.HDFS_CLASSPATH.tonyParamName + " " + hdfsClasspath);
     }
 
     Map<String, String> workerEnvs = getJobProps().getMapByPrefix(WORKER_ENV_PREFIX);
     for (Map.Entry<String, String> workerEnv : workerEnvs.entrySet()) {
-      args.append(" " + TensorFlowJobArg.SHELL_ENV.tonyParamName + " " + workerEnv.getKey()
+      args.append(" " + TonyJobArg.SHELL_ENV.tonyParamName + " " + workerEnv.getKey()
           + "=" + workerEnv.getValue());
     }
 
-    String taskParams = getJobProps().getString(TensorFlowJobArg.TASK_PARAMS.azPropName, null);
+    String taskParams = getJobProps().getString(TonyJobArg.TASK_PARAMS.azPropName, null);
     if (taskParams != null) {
-      args.append(" " + TensorFlowJobArg.TASK_PARAMS.tonyParamName + " '" + taskParams + "'");
+      args.append(" " + TonyJobArg.TASK_PARAMS.tonyParamName + " '" + taskParams + "'");
     }
 
-    String pythonBinaryPath = getJobProps().getString(TensorFlowJobArg.PYTHON_BINARY_PATH.azPropName, null);
+    String pythonBinaryPath = getJobProps().getString(TonyJobArg.PYTHON_BINARY_PATH.azPropName, null);
     if (pythonBinaryPath != null) {
-      args.append(" " + TensorFlowJobArg.PYTHON_BINARY_PATH.tonyParamName + " " + pythonBinaryPath);
+      args.append(" " + TonyJobArg.PYTHON_BINARY_PATH.tonyParamName + " " + pythonBinaryPath);
     }
 
-    String pythonVenv = getJobProps().getString(TensorFlowJobArg.PYTHON_VENV.azPropName, null);
+    String pythonVenv = getJobProps().getString(TonyJobArg.PYTHON_VENV.azPropName, null);
     if (pythonVenv != null) {
-      args.append(" " + TensorFlowJobArg.PYTHON_VENV.tonyParamName + " " + pythonVenv);
+      args.append(" " + TonyJobArg.PYTHON_VENV.tonyParamName + " " + pythonVenv);
     }
 
-    String executes = getJobProps().getString(TensorFlowJobArg.EXECUTES.azPropName, null);
+    String executes = getJobProps().getString(TonyJobArg.EXECUTES.azPropName, null);
     if (executes != null) {
-      args.append(" " + TensorFlowJobArg.EXECUTES.tonyParamName + " " + executes);
+      args.append(" " + TonyJobArg.EXECUTES.tonyParamName + " " + executes);
     }
 
     Map<String, String> tonyConfs = getJobProps().getMapByPrefix(TONY_CONF_PREFIX);
@@ -128,8 +128,10 @@ public class TensorFlowJob extends HadoopJavaJob {
     }
 
     // Write user's tony confs to an xml to be localized.
-    if (!tonyConfFile.getParentFile().mkdir()) {
-      throw new RuntimeException("Failed to create parent directory for TonY conf file.");
+    File parentDir = tonyConfFile.getParentFile();
+    if (!parentDir.mkdirs() && !parentDir.exists()) {
+      throw new RuntimeException("Failed to create parent directory " + tonyConfFile.getParentFile()
+          + " for TonY conf file.");
     }
     try (OutputStream os = new FileOutputStream(tonyConfFile)) {
       tfConf.writeXml(os);

--- a/tony-azkaban/src/main/java/com/linkedin/tony/azkaban/TonyJobArg.java
+++ b/tony-azkaban/src/main/java/com/linkedin/tony/azkaban/TonyJobArg.java
@@ -4,8 +4,8 @@
  */
 package com.linkedin.tony.azkaban;
 
-// Standard TensorFlow submit arguments.
-public enum TensorFlowJobArg {
+// Standard TonY job arguments.
+public enum TonyJobArg {
   HDFS_CLASSPATH("hdfs_classpath"),
   SHELL_ENV("shell_env"),
   TASK_PARAMS("task_params"),
@@ -14,7 +14,7 @@ public enum TensorFlowJobArg {
   EXECUTES("executes"),
   SRC_DIR("src_dir");
 
-  TensorFlowJobArg(String azPropName) {
+  TonyJobArg(String azPropName) {
     this.azPropName = azPropName;
     this.tonyParamName = "-" + azPropName;
   }

--- a/tony-azkaban/src/test/java/com/linkedin/tony/azkaban/TestTonyJob.java
+++ b/tony-azkaban/src/test/java/com/linkedin/tony/azkaban/TestTonyJob.java
@@ -50,14 +50,14 @@ public class TestTonyJob {
     jobProps.put(TonyJob.WORKER_ENV_PREFIX + "E1", "e1");
     jobProps.put(TonyJob.WORKER_ENV_PREFIX + "E2", "e2");
 
-    final TonyJob tfJob = new TonyJob("test_tf_job", new Props(), jobProps, log) {
+    final TonyJob tonyJob = new TonyJob("test_tony_job", new Props(), jobProps, log) {
       @Override
       public String getWorkingDirectory() {
         return System.getProperty("java.io.tmpdir");
       }
     };
-    String args = tfJob.getMainArguments();
-    Assert.assertTrue(new File(tfJob.getWorkingDirectory(), "_tony-conf-test_tf_job/tony.xml").exists());
+    String args = tonyJob.getMainArguments();
+    Assert.assertTrue(new File(tonyJob.getWorkingDirectory(), "_tony-conf-test_tony_job/tony.xml").exists());
     Assert.assertTrue(args.contains(TonyJobArg.HDFS_CLASSPATH.tonyParamName + " hdfs://nn:8020"));
     Assert.assertTrue(args.contains(TonyJobArg.SHELL_ENV.tonyParamName + " E2=e2"));
     Assert.assertTrue(args.contains(TonyJobArg.SHELL_ENV.tonyParamName + " E1=e1"));
@@ -70,13 +70,13 @@ public class TestTonyJob {
     jobProps.put(TonyJob.WORKING_DIR, FilenameUtils.getFullPath(FileIOUtils.getSourcePathFromClass(Props.class)));
     sysProps.put("jobtype.classpath", "123,456,789");
     sysProps.put("plugin.dir", "Plugins");
-    final TonyJob tfJob = new TonyJob("test_tf_job_class_path", sysProps, jobProps, log) {
+    final TonyJob tonyJob = new TonyJob("test_tony_job_class_path", sysProps, jobProps, log) {
       @Override
       public String getWorkingDirectory() {
         return System.getProperty("java.io.tmpdir");
       }
     };
-    List<String> paths = tfJob.getClassPaths();
+    List<String> paths = tonyJob.getClassPaths();
     int counter = 0;
     for (String path : paths) {
       if (path.contains("Plugins/123") || path.contains("Plugins/456") || path.contains("Plugins/789")) {
@@ -84,6 +84,6 @@ public class TestTonyJob {
       }
     }
     Assert.assertTrue(counter == 3);
-    Assert.assertTrue(paths.contains(new File(tfJob.getWorkingDirectory(), "_tony-conf-test_tf_job_class_path").toString()));
+    Assert.assertTrue(paths.contains(new File(tonyJob.getWorkingDirectory(), "_tony-conf-test_tony_job_class_path").toString()));
   }
 }

--- a/tony-azkaban/src/test/java/com/linkedin/tony/azkaban/TestTonyJob.java
+++ b/tony-azkaban/src/test/java/com/linkedin/tony/azkaban/TestTonyJob.java
@@ -21,9 +21,9 @@ import org.testng.annotations.Test;
 import static azkaban.ServiceProvider.SERVICE_PROVIDER;
 
 
-public class TestTensorFlowJob {
+public class TestTonyJob {
 
-  private final Logger log = Logger.getLogger(TestTensorFlowJob.class);
+  private final Logger log = Logger.getLogger(TestTonyJob.class);
 
   // Taken from azkaban.test.Utils in azkaban-common.
   private static void initServiceProvider() {
@@ -46,11 +46,11 @@ public class TestTensorFlowJob {
   @Test
   public void testMainArguments() {
     final Props jobProps = new Props();
-    jobProps.put(TensorFlowJobArg.HDFS_CLASSPATH.azPropName, "hdfs://nn:8020");
-    jobProps.put(TensorFlowJob.WORKER_ENV_PREFIX + "E1", "e1");
-    jobProps.put(TensorFlowJob.WORKER_ENV_PREFIX + "E2", "e2");
+    jobProps.put(TonyJobArg.HDFS_CLASSPATH.azPropName, "hdfs://nn:8020");
+    jobProps.put(TonyJob.WORKER_ENV_PREFIX + "E1", "e1");
+    jobProps.put(TonyJob.WORKER_ENV_PREFIX + "E2", "e2");
 
-    final TensorFlowJob tfJob = new TensorFlowJob("test_tf_job", new Props(), jobProps, log) {
+    final TonyJob tfJob = new TonyJob("test_tf_job", new Props(), jobProps, log) {
       @Override
       public String getWorkingDirectory() {
         return System.getProperty("java.io.tmpdir");
@@ -58,19 +58,19 @@ public class TestTensorFlowJob {
     };
     String args = tfJob.getMainArguments();
     Assert.assertTrue(new File(tfJob.getWorkingDirectory(), "_tony-conf-test_tf_job/tony.xml").exists());
-    Assert.assertTrue(args.contains(TensorFlowJobArg.HDFS_CLASSPATH.tonyParamName + " hdfs://nn:8020"));
-    Assert.assertTrue(args.contains(TensorFlowJobArg.SHELL_ENV.tonyParamName + " E2=e2"));
-    Assert.assertTrue(args.contains(TensorFlowJobArg.SHELL_ENV.tonyParamName + " E1=e1"));
+    Assert.assertTrue(args.contains(TonyJobArg.HDFS_CLASSPATH.tonyParamName + " hdfs://nn:8020"));
+    Assert.assertTrue(args.contains(TonyJobArg.SHELL_ENV.tonyParamName + " E2=e2"));
+    Assert.assertTrue(args.contains(TonyJobArg.SHELL_ENV.tonyParamName + " E1=e1"));
   }
 
   @Test
   public void testClassPaths() {
     final Props sysProps = new Props();
     final Props jobProps = new Props();
-    jobProps.put(TensorFlowJob.WORKING_DIR, FilenameUtils.getFullPath(FileIOUtils.getSourcePathFromClass(Props.class)));
+    jobProps.put(TonyJob.WORKING_DIR, FilenameUtils.getFullPath(FileIOUtils.getSourcePathFromClass(Props.class)));
     sysProps.put("jobtype.classpath", "123,456,789");
     sysProps.put("plugin.dir", "Plugins");
-    final TensorFlowJob tfJob = new TensorFlowJob("test_tf_job_class_path", sysProps, jobProps, log) {
+    final TonyJob tfJob = new TonyJob("test_tf_job_class_path", sysProps, jobProps, log) {
       @Override
       public String getWorkingDirectory() {
         return System.getProperty("java.io.tmpdir");


### PR DESCRIPTION
* Renamed TensorFlowJob and TensorFlowJobArg to TonyJob and TonyJobArg. Used a lowercase 'y' in the new names to match naming convention used by TonyClient and TonyApplicationMaster.