### PR TITLE
Fix ./gradlew :tony-core:shadowJar fails with "shadow.org.apache.tools.zip.Zip64RequiredException: archive contains more than 65535 entries" #181

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 .vscode/
 build/
 dependency-reduced-pom.xml
+ligradle/
 log/
 out/
 target

--- a/build.gradle
+++ b/build.gradle
@@ -95,11 +95,11 @@ subprojects {
   apply plugin: "idea"
   apply plugin: "maven-publish"
   apply plugin: "signing"
-  apply plugin: 'com.github.johnrengelman.shadow'
 
   apply from: "$rootDir/gradle/version-info.gradle"
 
   if (project.name.equals("tony-cli")) {
+    apply plugin: 'com.github.johnrengelman.shadow'
     shadowJar {
       mergeServiceFiles()
       dependencies {


### PR DESCRIPTION
The Shadow plugin should only be applied to the `tony-cli` submodule, not all modules. `tony-core` does not need to build a fat jar, since the `tony-cli-all` fat jar already contains all of `tony-core`.