### PR TITLE
Fix #190 and #189: "ClusterSubmitter adds cachedLibPath resource to wrong conf" and "TonY should use localhost as default TonY history host"

### DIFF
--- a/tony-cli/src/main/java/com/linkedin/tony/cli/ClusterSubmitter.java
+++ b/tony-cli/src/main/java/com/linkedin/tony/cli/ClusterSubmitter.java
@@ -38,7 +38,7 @@ public class ClusterSubmitter extends TonySubmitter {
   private TonyClient client;
 
   private ClusterSubmitter() {
-    this.client = new TonyClient(new Configuration());
+    this(new TonyClient(new Configuration()));
   }
   public ClusterSubmitter(TonyClient client) {
     this.client = client;
@@ -55,8 +55,8 @@ public class ClusterSubmitter extends TonySubmitter {
     Path cachedLibPath = null;
     try (FileSystem fs = FileSystem.get(hdfsConf)) {
       cachedLibPath = new Path(fs.getHomeDirectory(), TONY_FOLDER + Path.SEPARATOR + UUID.randomUUID().toString());
-      Utils.uploadFileAndSetConfResources(cachedLibPath, new Path(jarLocation),
-              TONY_JAR_NAME, hdfsConf, fs, LocalResourceType.FILE, TonyConfigurationKeys.getContainerResourcesKey());
+      Utils.uploadFileAndSetConfResources(cachedLibPath, new Path(jarLocation), TONY_JAR_NAME, client.getTonyConf(), fs,
+          LocalResourceType.FILE, TonyConfigurationKeys.getContainerResourcesKey());
       LOG.info("Copying " + jarLocation + " to: " + cachedLibPath);
       boolean sanityCheck = client.init(args);
       if (!sanityCheck) {

--- a/tony-cli/src/test/java/com/linkedin/tony/TestClusterSubmitter.java
+++ b/tony-cli/src/test/java/com/linkedin/tony/TestClusterSubmitter.java
@@ -12,16 +12,16 @@ import static org.testng.Assert.*;
 
 
 public class TestClusterSubmitter {
-
   @Test
-  public void testClusterSubmmiter() throws  Exception {
+  public void testClusterSubmitter() throws  Exception {
     TonyClient client = spy(new TonyClient());
     doReturn(0).when(client).start(); // Don't really call start() method.
 
     ClusterSubmitter submitter = new ClusterSubmitter(client);
     int exitCode = submitter.submit(new String[] {"--src_dir", "src"});
     assertEquals(exitCode, 0);
+    assertTrue(
+        client.getTonyConf().get(TonyConfigurationKeys.getContainerResourcesKey()).contains(Constants.TONY_JAR_NAME));
   }
-
 }
 

--- a/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
@@ -402,7 +402,6 @@ public class TonyClient implements AutoCloseable {
   @VisibleForTesting
   public void processTonyConfResources(Configuration tonyConf, FileSystem fs) throws IOException {
     Set<String> jobNames = tonyConf.getValByRegex(TonyConfigurationKeys.RESOURCES_REGEX).keySet();
-
     for (String jobName : jobNames) {
       String[] resources = tonyConf.getStrings(jobName);
       if (resources == null) {

--- a/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
@@ -29,9 +29,6 @@ public class TonyConfigurationKeys {
   public static final String OTHER_NAMENODES_TO_ACCESS = TONY_PREFIX + "other.namenodes";
 
   // History folder configuration
-  public static final String TONY_HISTORY_HOST = TONY_PREFIX + "history.host";
-  public static final String DEFAULT_TONY_HISTORY_HOST = "historyhost.com";
-
   public static final String TONY_HISTORY_LOCATION = TONY_PREFIX + "history.location";
   public static final String DEFAULT_TONY_HISTORY_LOCATION = "/path/to/tony-history";
 
@@ -75,6 +72,9 @@ public class TonyConfigurationKeys {
 
   public static final String TONY_HISTORY_MAX_APPEND = TONY_PREFIX + "history.maxAppends";
   public static final int DEFAULT_TONY_HISTORY_MAX_APPEND = 3;
+
+  public static final String TONY_HISTORY_HOST = TONY_PREFIX + "history.host";
+  public static final String DEFAULT_TONY_HISTORY_HOST = "https://localhost:" + DEFAULT_TONY_HTTPS_PORT;
 
   // Application configurations
   public static final String YARN_QUEUE_NAME = TONY_PREFIX + "yarn.queue";

--- a/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
+++ b/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
@@ -197,7 +197,7 @@ public class Utils {
 
   public static void printTHSUrl(String thsHost, String appId, Log log) {
     log.info(
-        String.format("Link for %s's events/metrics: http://%s/%s/%s", appId, thsHost, Constants.JOBS_SUFFIX, appId));
+        String.format("Link for %s's events/metrics: %s/%s/%s", appId, thsHost, Constants.JOBS_SUFFIX, appId));
   }
 
   /**
@@ -519,6 +519,9 @@ public class Utils {
   }
 
   public static void appendConfResources(String key, String resource, Configuration tonyConf) {
+    if (resource == null) {
+      return;
+    }
     String[] resources = tonyConf.getStrings(key);
     List<String> updatedResources = new ArrayList<>();
     if (resources != null) {

--- a/tony-core/src/main/resources/tony-default.xml
+++ b/tony-core/src/main/resources/tony-default.xml
@@ -209,7 +209,7 @@
       Hostname of history server
     </description>
     <name>tony.history.host</name>
-    <value>historyhost.com</value>
+    <value>https://localhost:19886</value>
   </property>
 
   <property>


### PR DESCRIPTION
Previously, launching a job via `ClusterSubmitter` would fail because `tony.jar` is not in the AM's classpath so the `TonyApplicationMaster` class cannot be found. This happened because `ClusterSubmitter` adds `tony.jar` to a local `hdfsConf`, but the resource is never added to the `tonyConf` used by the `TonyClient`.

Fixed this by updating `ClusterSubmitter` to add `tony.jar` to the `TonyClient`'s `tonyConf`.

Tested locally. Added unit test.