### PR TITLE
Fix TonY race condition between worker termination notification and heartbeat liveness checker unregistration #198

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/Constants.java
+++ b/tony-core/src/main/java/com/linkedin/tony/Constants.java
@@ -84,7 +84,7 @@ public class Constants {
 
   public static final String TEST_AM_CRASH = "TEST_AM_CRASH";
   public static final String TEST_WORKER_TERMINATED = "TEST_WORKER_TERMINATION";
-  public static final String TEST_TASK_EXECUTOR_HANG = "TEST_TASK_EXECUTOR_HANG";
+  public static final String TEST_TASK_COMPLETION_NOTIFICATION_DELAYED = "TEST_TASK_COMPLETION_NOTIFICATION_DELAYED";
   public static final String TEST_TASK_EXECUTOR_NUM_HB_MISS = "TEST_TASK_EXECUTOR_NUM_HB_MISS";
   // Should be of the form type#id#ms
   public static final String TEST_TASK_EXECUTOR_SKEW = "TEST_TASK_EXECUTOR_SKEW";

--- a/tony-core/src/main/java/com/linkedin/tony/TonyApplicationMaster.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyApplicationMaster.java
@@ -996,14 +996,8 @@ public class TonyApplicationMaster {
     @Override
     public void onContainersCompleted(List<ContainerStatus> completedContainers) {
       LOG.info("Completed containers: " + completedContainers.size());
-      if (System.getenv(Constants.TEST_TASK_COMPLETION_NOTIFICATION_DELAYED) != null) {
-        LOG.info("Sleeping for 1 second to simulate task completion notification delay");
-        try {
-          Thread.sleep(1000);
-        } catch (InterruptedException e) {
-          LOG.error(e);
-        }
-      }
+      sleepForTesting();
+
       for (ContainerStatus containerStatus : completedContainers) {
         int exitStatus = containerStatus.getExitStatus();
         LOG.info("ContainerID = " + containerStatus.getContainerId()
@@ -1030,6 +1024,20 @@ public class TonyApplicationMaster {
           }
         } else {
           LOG.warn("No task found for container : [" + containerStatus.getContainerId() + "]!");
+        }
+      }
+    }
+
+    /**
+     * For testing purposes to simulate delay of container completion callback.
+     */
+    private void sleepForTesting() {
+      if (System.getenv(Constants.TEST_TASK_COMPLETION_NOTIFICATION_DELAYED) != null) {
+        LOG.info("Sleeping for 1 second to simulate task completion notification delay");
+        try {
+          Thread.sleep(1000);
+        } catch (InterruptedException e) {
+          LOG.error(e);
         }
       }
     }

--- a/tony-core/src/main/java/com/linkedin/tony/TonyApplicationMaster.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyApplicationMaster.java
@@ -858,12 +858,24 @@ public class TonyApplicationMaster {
      * However, this easily introduces lots of bugs since we'd have 3 places to handle failures - register call, container
      * complete callback and heartbeat.
      * To make things easier, we decide to go back and piggyback on container completion to dictate the execution result
-     * of a task.
-     * Still keep this RPC call here for now.
+     * of a task. However, we use this method to unregister a completed task from the heartbeat monitor to avoid a race
+     * condition where the container complete callback is delayed, too many heartbeats are missed, and the task is
+     * marked as failed.
      */
     @Override
     public String registerExecutionResult(int exitCode, String jobName, String jobIndex, String sessionId) {
       LOG.info("Received result registration request with exit code " + exitCode + " from " + jobName + " " + jobIndex);
+
+      // Unregister task after completion..
+      // Since in the case of asynchronous exec, containers might
+      // end at different times..
+      TonyTask task = session.getTask(jobName + ":" + jobIndex);
+      if (task != null) {
+        LOG.info("Unregistering task [" + task.getId() + "] from Heartbeat monitor..");
+        hbMonitor.unregister(task);
+      } else {
+        LOG.warn("Task " + jobName + " " + jobIndex + " was null!");
+      }
       return "RECEIVED";
     }
 
@@ -984,6 +996,14 @@ public class TonyApplicationMaster {
     @Override
     public void onContainersCompleted(List<ContainerStatus> completedContainers) {
       LOG.info("Completed containers: " + completedContainers.size());
+      if (System.getenv(Constants.TEST_TASK_COMPLETION_NOTIFICATION_DELAYED) != null) {
+        LOG.info("Sleeping for 1 second to simulate task completion notification delay");
+        try {
+          Thread.sleep(1000);
+        } catch (InterruptedException e) {
+          LOG.error(e);
+        }
+      }
       for (ContainerStatus containerStatus : completedContainers) {
         int exitStatus = containerStatus.getExitStatus();
         LOG.info("ContainerID = " + containerStatus.getContainerId()
@@ -1008,12 +1028,6 @@ public class TonyApplicationMaster {
           if (Utils.isJobTypeTracked(task.getJobName(), tonyConf)) {
             numCompletedTrackedTasks.incrementAndGet();
           }
-
-          // Unregister task after completion..
-          // Since in the case of asynchronous exec, containers might
-          // end at different times..
-          LOG.info("Unregister task [" + task.getId() + "] from Heartbeat monitor..");
-          hbMonitor.unregister(task);
         } else {
           LOG.warn("No task found for container : [" + containerStatus.getContainerId() + "]!");
         }

--- a/tony-core/src/test/java/com/linkedin/tony/TestTonyE2E.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestTonyE2E.java
@@ -20,7 +20,8 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static com.linkedin.tony.TonyConfigurationKeys.*;
+import static com.linkedin.tony.TonyConfigurationKeys.TASK_HEARTBEAT_INTERVAL_MS;
+import static com.linkedin.tony.TonyConfigurationKeys.TASK_MAX_MISSED_HEARTBEATS;
 
 
 /**


### PR DESCRIPTION
Moved unregistration of task from heartbeat monitor into `registerExecutionResult()` to avoid the race condition.

Internal Jira: LIHADOOP-44694