### PR TITLE
Fix bug when src_dir contains directory in the current directory or multiple directories

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
@@ -9,6 +9,7 @@ import azkaban.utils.Props;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.io.Files;
 import com.linkedin.tony.rpc.TaskUrl;
 import com.linkedin.tony.rpc.impl.ApplicationRpcClient;
 import com.linkedin.tony.tensorflow.TensorFlowContainerRequest;
@@ -463,7 +464,8 @@ public class TonyClient implements AutoCloseable {
                       fs, LocalResourceType.FILE, jobName);
             }
           } else {
-            Utils.zipFolder(Paths.get(srcDir), Paths.get(file.getName()));
+            File tmpDir = Files.createTempDir();
+            Utils.zipFolder(Paths.get(resource), Paths.get(tmpDir.getAbsolutePath(), file.getName()));
             Utils.uploadFileAndSetConfResources(appResourcesPath,
                     new Path(trimmedResource),
                     new Path(trimmedResource).getName(),


### PR DESCRIPTION
This PR fixes error where TonyClient is not working when src directory is in the same directory of currently working directory or multiple directories is in src dir introduced in https://github.com/linkedin/TonY/pull/187.