### PR TITLE
Add ClientCallbackHandler to pass back ApplicationId and TaskUrl

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ ext.deps = [
 
 allprojects {
   group = "com.linkedin.tony"
-  project.version = "0.2.0"
+  project.version = "0.2.0-SNAPSHOT"
 }
 
 task sourcesJar(type: Jar) {

--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ ext.deps = [
 
 allprojects {
   group = "com.linkedin.tony"
-  project.version = "0.2.0-SNAPSHOT"
+  project.version = "0.2.0"
 }
 
 task sourcesJar(type: Jar) {

--- a/tony-cli/src/main/java/com/linkedin/tony/cli/NotebookSubmitter.java
+++ b/tony-cli/src/main/java/com/linkedin/tony/cli/NotebookSubmitter.java
@@ -128,7 +128,7 @@ public class NotebookSubmitter extends TonySubmitter implements ClientCallbackHa
 
   // ClientCallbackHandler callbacks
   public void onApplicationIdReceived(ApplicationId appId) { }
-  public void onTaskUrlReceived(Set<TaskUrl> taskUrlSet) {
+  public void onTaskUrlsReceived(Set<TaskUrl> taskUrlSet) {
     this.taskUrlSet = taskUrlSet;
   }
 

--- a/tony-cli/src/main/java/com/linkedin/tony/cli/NotebookSubmitter.java
+++ b/tony-cli/src/main/java/com/linkedin/tony/cli/NotebookSubmitter.java
@@ -4,6 +4,7 @@
  */
 package com.linkedin.tony.cli;
 
+import com.linkedin.tony.ClientCallbackHandler;
 import com.linkedin.tony.Constants;
 import com.linkedin.tony.TonyClient;
 import com.linkedin.tony.TonyConfigurationKeys;
@@ -15,6 +16,7 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.URISyntaxException;
 import java.util.Arrays;
+import java.util.Set;
 import java.util.UUID;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
@@ -23,6 +25,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 
 import static com.linkedin.tony.Constants.*;
@@ -41,10 +44,11 @@ import static com.linkedin.tony.Constants.*;
  * CLASSPATH=$(${HADOOP_HDFS_HOME}/bin/hadoop classpath --glob):./:/home/khu/notebook/tony-cli-0.1.0-all.jar \
  * java com.linkedin.tony.cli.NotebookSubmitter --src_dir bin/ --executes "'bin/linotebook --ip=* $DISABLE_TOKEN'"
  */
-public class NotebookSubmitter extends TonySubmitter {
+public class NotebookSubmitter extends TonySubmitter implements ClientCallbackHandler {
   private static final Log LOG = LogFactory.getLog(NotebookSubmitter.class);
 
   private TonyClient client;
+  private Set<TaskUrl> taskUrlSet;
 
   private NotebookSubmitter() {
     this.client = new TonyClient(new Configuration());
@@ -91,8 +95,8 @@ public class NotebookSubmitter extends TonySubmitter {
     }));
     clientThread.start();
     while (clientThread.isAlive()) {
-      if (client.getTaskUrls() != null) {
-        for (TaskUrl taskUrl : client.getTaskUrls()) {
+      if (taskUrlSet != null) {
+        for (TaskUrl taskUrl : taskUrlSet) {
           if (taskUrl.getName().equals(Constants.NOTEBOOK_JOB_NAME)) {
             String[] hostPort = taskUrl.getUrl().split(":");
             ServerSocket localSocket = new ServerSocket(0);
@@ -121,4 +125,11 @@ public class NotebookSubmitter extends TonySubmitter {
     exitCode = submitter.submit(args);
     System.exit(exitCode);
   }
+
+  // ClientCallbackHandler callbacks
+  public void onApplicationIdReceived(ApplicationId appId) { }
+  public void onTaskUrlReceived(Set<TaskUrl> taskUrlSet) {
+    this.taskUrlSet = taskUrlSet;
+  }
+
 }

--- a/tony-core/src/main/java/com/linkedin/tony/ClientCallbackHandler.java
+++ b/tony-core/src/main/java/com/linkedin/tony/ClientCallbackHandler.java
@@ -1,0 +1,15 @@
+/**
+ * Copyright 2018 LinkedIn Corporation. All rights reserved. Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.tony;
+
+import com.linkedin.tony.rpc.TaskUrl;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+
+import java.util.Set;
+
+public interface ClientCallbackHandler {
+    void onApplicationIdReceived(ApplicationId appId);
+    void onTaskUrlReceived(Set<TaskUrl> taskUrlSet);
+}

--- a/tony-core/src/main/java/com/linkedin/tony/ClientCallbackHandler.java
+++ b/tony-core/src/main/java/com/linkedin/tony/ClientCallbackHandler.java
@@ -10,6 +10,6 @@ import org.apache.hadoop.yarn.api.records.ApplicationId;
 import java.util.Set;
 
 public interface ClientCallbackHandler {
-    void onApplicationIdReceived(ApplicationId appId);
-    void onTaskUrlReceived(Set<TaskUrl> taskUrlSet);
+    public void onApplicationIdReceived(ApplicationId appId);
+    public void onTaskUrlReceived(Set<TaskUrl> taskUrlSet);
 }

--- a/tony-core/src/main/java/com/linkedin/tony/ClientCallbackHandler.java
+++ b/tony-core/src/main/java/com/linkedin/tony/ClientCallbackHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 LinkedIn Corporation. All rights reserved. Licensed under the BSD-2 Clause license.
+ * Copyright 2019 LinkedIn Corporation. All rights reserved. Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
 package com.linkedin.tony;
@@ -9,7 +9,14 @@ import org.apache.hadoop.yarn.api.records.ApplicationId;
 
 import java.util.Set;
 
+/**
+ * ClientCallbackHandler is used to get callbacks from TonyClient when some
+ * asynchronous information becomes available.
+ */
 public interface ClientCallbackHandler {
+    // Called when TonyClient gets an application id response from RM.
     public void onApplicationIdReceived(ApplicationId appId);
-    public void onTaskUrlReceived(Set<TaskUrl> taskUrlSet);
+
+    // Called when TonyClient gets a set of taskUrls from TonyAM.
+    public void onTaskUrlsReceived(Set<TaskUrl> taskUrlSet);
 }

--- a/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
@@ -737,10 +737,10 @@ public class TonyClient implements AutoCloseable {
       if (amRpcServerInitialized && taskUrls.isEmpty()) {
         taskUrls = amRpcClient.getTaskUrls();
         if (!taskUrls.isEmpty()) {
-          // Print TaskUrls
           if (callbackHandler != null) {
-            callbackHandler.onTaskUrlReceived(ImmutableSet.copyOf(taskUrls));
+            callbackHandler.onTaskUrlsReceived(ImmutableSet.copyOf(taskUrls));
           }
+          // Print TaskUrls
           new TreeSet<>(taskUrls).forEach(task -> Utils.printTaskUrl(task, LOG));
         }
       }

--- a/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
@@ -145,10 +145,6 @@ public class TonyClient implements AutoCloseable {
     VersionInfo.injectVersionInfo(tonyConf);
   }
 
-  private ImmutableSet<TaskUrl> getTaskUrls() {
-    return ImmutableSet.copyOf(taskUrls);
-  }
-
   private boolean run() throws IOException, InterruptedException, URISyntaxException, YarnException {
     LOG.info("Starting client..");
     yarnClient.start();


### PR DESCRIPTION
We current expose taskUrlSet to NotebookSubmitter through exposing that field in TonyClient, that doesn't look good. Also, we need applicationId passed back to `TonyRuntime` .