### PR TITLE
Fix #218: NotebookSubmitter broken after #207

### DIFF
--- a/tony-cli/src/test/java/com/linkedin/tony/cli/TestClusterSubmitter.java
+++ b/tony-cli/src/test/java/com/linkedin/tony/cli/TestClusterSubmitter.java
@@ -9,8 +9,10 @@ import com.linkedin.tony.TonyClient;
 import com.linkedin.tony.TonyConfigurationKeys;
 import org.testng.annotations.Test;
 
-import static org.mockito.Mockito.*;
-import static org.testng.Assert.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 
 public class TestClusterSubmitter {

--- a/tony-cli/src/test/java/com/linkedin/tony/cli/TestClusterSubmitter.java
+++ b/tony-cli/src/test/java/com/linkedin/tony/cli/TestClusterSubmitter.java
@@ -2,9 +2,11 @@
  * Copyright 2018 LinkedIn Corporation. All rights reserved. Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
-package com.linkedin.tony;
+package com.linkedin.tony.cli;
 
-import com.linkedin.tony.cli.ClusterSubmitter;
+import com.linkedin.tony.Constants;
+import com.linkedin.tony.TonyClient;
+import com.linkedin.tony.TonyConfigurationKeys;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.*;

--- a/tony-cli/src/test/java/com/linkedin/tony/cli/TestNotebookSubmitter.java
+++ b/tony-cli/src/test/java/com/linkedin/tony/cli/TestNotebookSubmitter.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2019 LinkedIn Corporation. All rights reserved. Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.tony.cli;
+
+import com.linkedin.tony.TonyClient;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestNotebookSubmitter {
+  @Test
+  public void testCallbackHandlerSet() {
+    NotebookSubmitter ns = new NotebookSubmitter();
+    TonyClient client = ns.getClient();
+    Assert.assertNotNull(client.getCallbackHandler());
+  }
+}

--- a/tony-core/src/main/java/com/linkedin/tony/TonyApplicationMaster.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyApplicationMaster.java
@@ -701,8 +701,8 @@ public class TonyApplicationMaster {
       int tbPort = tbSocket.getLocalPort();
       extraEnv.put(Constants.TB_PORT, String.valueOf(tbPort));
       String tbUrl = Utils.getCurrentHostName() + ":" + tbPort;
-      proxyUrl = tbUrl;
-      LOG.info("Registering tensorboard url for single node training: " + tbUrl);
+      proxyUrl = Utils.constructUrl(tbUrl);
+      LOG.info("Registering TensorBoard url for single node training: " + tbUrl);
       registerTensorBoardUrlToRM(tbUrl);
       tbSocket.close();
     }

--- a/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
@@ -825,7 +825,10 @@ public class TonyClient implements AutoCloseable {
     if (appId != null) {
       yarnClient.killApplication(appId);
     }
+  }
 
+  public ClientCallbackHandler getCallbackHandler() {
+    return callbackHandler;
   }
 
   protected ApplicationRpcClient getAMRpcClient() {

--- a/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
+++ b/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
@@ -173,13 +173,15 @@ public class Utils {
     resource.setResourceValue(GPU_URI, gpuCount);
   }
 
-  public static String constructContainerUrl(Container container) {
-    try {
-      return String.format(WORKER_LOG_URL_TEMPLATE, container.getNodeHttpAddress(), container.getId(),
-          UserGroupInformation.getCurrentUser().getShortUserName());
-    } catch (IOException e) {
-      throw new RuntimeException(e);
+  public static String constructUrl(String urlString) {
+    if (!urlString.startsWith("http")) {
+      return "http://" + urlString;
     }
+    return urlString;
+  }
+
+  public static String constructContainerUrl(Container container) {
+    return constructContainerUrl(container.getNodeHttpAddress(), container.getId());
   }
 
   public static String constructContainerUrl(String nodeAddress, ContainerId containerId) {


### PR DESCRIPTION
* Fixed NotebookSubmitter by passing callback handler to TonyClient
* Added unit test for this
* Enhanced ClusterSubmitter to kill any running application when it's terminated (e.g.: when Ctrl-C is pressed)
* Updated notebook URL to include "http://" prefix