### PR TITLE
TonY should allow setting limit per resource type #236

### DIFF
--- a/tony-core/build.gradle
+++ b/tony-core/build.gradle
@@ -46,6 +46,7 @@ test {
 
 test.dependsOn(setupHdfsLib)
 
+def generatedSourcesDir = file('src/generated/main/java')
 sourceSets {
   main {
     proto {
@@ -55,7 +56,7 @@ sourceSets {
     }
 
     java {
-      srcDirs += ['src/generated/main/java']
+      srcDirs += [generatedSourcesDir]
     }
   }
 }
@@ -77,3 +78,9 @@ clean {
 // The `generateProto` task is dynamically generated and is not available at configuration time,
 // so we need to refer to it by a string name here
 ideaModule.dependsOn 'generateProto'
+idea {
+  module {
+    sourceDirs += generatedSourcesDir
+    generatedSourceDirs += generatedSourcesDir
+  }
+}

--- a/tony-core/build.gradle
+++ b/tony-core/build.gradle
@@ -80,6 +80,8 @@ clean {
 ideaModule.dependsOn 'generateProto'
 idea {
   module {
+    // For some reason, you need to add the generated sources dir to *both* sourceDirs and generatedSourceDirs
+    // in order for IDEA to mark it properly.
     sourceDirs += generatedSourcesDir
     generatedSourceDirs += generatedSourcesDir
   }

--- a/tony-core/src/main/java/com/linkedin/tony/Constants.java
+++ b/tony-core/src/main/java/com/linkedin/tony/Constants.java
@@ -124,5 +124,10 @@ public class Constants {
   // Module relative path
   public static final String TONY_CORE_SRC = "./tony-core/src/";
 
+  // YARN resources
+  public static final String MEMORY = "memory";
+  public static final String VCORES = "vcores";
+  public static final String GPUS = "gpus";
+
   private Constants() { }
 }

--- a/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
@@ -85,8 +85,6 @@ import org.apache.hadoop.yarn.security.client.ClientToAMTokenIdentifier;
 import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.apache.hadoop.yarn.util.Records;
 
-import static com.linkedin.tony.TonyConfigurationKeys.DEFAULT_MAX_TOTAL_INSTANCES;
-
 
 /**
  * User entry point to submit tensorflow job.
@@ -664,7 +662,8 @@ public class TonyClient implements AutoCloseable {
     }
 
     // check that we don't request more than the allowed total tasks
-    int maxTotalInstances = tonyConf.getInt(TonyConfigurationKeys.MAX_TOTAL_INSTANCES, DEFAULT_MAX_TOTAL_INSTANCES);
+    int maxTotalInstances = tonyConf.getInt(TonyConfigurationKeys.MAX_TOTAL_INSTANCES,
+        TonyConfigurationKeys.DEFAULT_MAX_TOTAL_INSTANCES);
     int totalRequestedInstances = containerRequestMap.values().stream().mapToInt(TensorFlowContainerRequest::getNumInstances).sum();
     if (maxTotalInstances >= 0 && totalRequestedInstances > maxTotalInstances) {
       throw new RuntimeException("Job requested " + totalRequestedInstances + " total task instances but limit is "

--- a/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
@@ -112,7 +112,8 @@ public class TonyConfigurationKeys {
   /**
    * Max total number of task instances that can be requested across all task types.
    */
-  public static final String TONY_MAX_TOTAL_INSTANCES = TONY_TASK_PREFIX + "max-total-instances";
+  public static final String MAX_TOTAL_INSTANCES = TONY_TASK_PREFIX + "max-total-instances";
+  public static final int DEFAULT_MAX_TOTAL_INSTANCES = -1;
 
   public static final String TASK_EXECUTOR_JVM_OPTS = TONY_TASK_PREFIX + "executor.jvm.opts";
   public static final String DEFAULT_TASK_EXECUTOR_JVM_OPTS = "-Xmx1536m";
@@ -140,6 +141,7 @@ public class TonyConfigurationKeys {
 
   // Keys/default values for configurable TensorFlow job names
   public static final String INSTANCES_REGEX = "tony\\.([a-z]+)\\.instances";
+  public static final String MAX_TOTAL_RESOURCES_REGEX = TONY_TASK_PREFIX + "max-total-([a-z]+)";
   public static final String RESOURCES_REGEX = "tony\\.([a-z]+)\\.resources";
   public static final String DEFAULT_MEMORY = "2g";
   public static final int DEFAULT_VCORES = 1;
@@ -168,16 +170,12 @@ public class TonyConfigurationKeys {
     }
   }
 
-  public static String getMemoryKey(String jobName) {
-    return String.format(TONY_PREFIX + "%s.memory", jobName);
+  public static String getResourceKey(String jobName, String resource) {
+    return String.format(TONY_PREFIX + "%s.%s", jobName, resource);
   }
 
-  public static String getVCoresKey(String jobName) {
-    return String.format(TONY_PREFIX + "%s.vcores", jobName);
-  }
-
-  public static String getGPUsKey(String jobName) {
-    return String.format(TONY_PREFIX + "%s.gpus", jobName);
+  public static String getMaxTotalResourceKey(String resource) {
+    return String.format(TONY_TASK_PREFIX + "max-total-%s", resource);
   }
 
   // Job specific resources

--- a/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
+++ b/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
@@ -325,20 +325,18 @@ public class Utils {
    * @return map from configured job name to its corresponding resource request
    */
   public static Map<String, TensorFlowContainerRequest> parseContainerRequests(Configuration conf) {
-    Set<String> jobNames = conf.getValByRegex(TonyConfigurationKeys.INSTANCES_REGEX).keySet().stream()
-            .map(Utils::getTaskType)
-            .collect(Collectors.toSet());
+    Set<String> jobNames = getAllJobTypes(conf);
     Map<String, TensorFlowContainerRequest> containerRequests = new HashMap<>();
     int priority = 0;
     for (String jobName : jobNames) {
       int numInstances = conf.getInt(TonyConfigurationKeys.getInstancesKey(jobName),
               TonyConfigurationKeys.getDefaultInstances(jobName));
-      String memoryString = conf.get(TonyConfigurationKeys.getMemoryKey(jobName),
+      String memoryString = conf.get(TonyConfigurationKeys.getResourceKey(jobName, Constants.MEMORY),
               TonyConfigurationKeys.DEFAULT_MEMORY);
       long memory = Long.parseLong(parseMemoryString(memoryString));
-      int vCores = conf.getInt(TonyConfigurationKeys.getVCoresKey(jobName),
+      int vCores = conf.getInt(TonyConfigurationKeys.getResourceKey(jobName, Constants.VCORES),
               TonyConfigurationKeys.DEFAULT_VCORES);
-      int gpus = conf.getInt(TonyConfigurationKeys.getGPUsKey(jobName),
+      int gpus = conf.getInt(TonyConfigurationKeys.getResourceKey(jobName, Constants.GPUS),
               TonyConfigurationKeys.DEFAULT_GPUS);
 
       /* The priority of different task types MUST be different.
@@ -354,6 +352,12 @@ public class Utils {
       }
     }
     return containerRequests;
+  }
+
+  public static Set<String> getAllJobTypes(Configuration conf) {
+    return conf.getValByRegex(TonyConfigurationKeys.INSTANCES_REGEX).keySet().stream()
+        .map(Utils::getTaskType)
+        .collect(Collectors.toSet());
   }
 
   /**

--- a/tony-core/src/main/resources/tony-default.xml
+++ b/tony-core/src/main/resources/tony-default.xml
@@ -74,7 +74,7 @@
   <property>
     <name>tony.task.max-total-gpus</name>
     <value>-1</value>
-    <description>Maximum number of GPUs that can be requested across all tasks.</description>
+    <description>Maximum number of GPUs that can be requested across all tasks. -1 means no limit.</description>
   </property>
 
   <property>

--- a/tony-core/src/main/resources/tony-default.xml
+++ b/tony-core/src/main/resources/tony-default.xml
@@ -72,6 +72,12 @@
   </property>
 
   <property>
+    <name>tony.task.max-total-gpus</name>
+    <value>-1</value>
+    <description>Maximum number of GPUs that can be requested across all tasks.</description>
+  </property>
+
+  <property>
     <description>JVM opts for each TaskExecutor.</description>
     <name>tony.task.executor.jvm.opts</name>
     <value>-Xmx1536m</value>

--- a/tony-core/src/test/java/com/linkedin/tony/TestTonyConfigurationFields.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestTonyConfigurationFields.java
@@ -36,6 +36,7 @@ public class TestTonyConfigurationFields extends TestConfigurationFieldsBase {
     xmlPropsToSkipCompare.add(TonyConfigurationKeys.getResourceKey(Constants.WORKER_JOB_NAME, Constants.VCORES));
     xmlPropsToSkipCompare.add(TonyConfigurationKeys.getResourceKey(Constants.WORKER_JOB_NAME, Constants.GPUS));
     xmlPropsToSkipCompare.add(TonyConfigurationKeys.getResourcesKey(Constants.WORKER_JOB_NAME));
+    xmlPropsToSkipCompare.add(TonyConfigurationKeys.getMaxTotalResourceKey(Constants.GPUS));
     configurationPropsToSkipCompare.add(TonyConfigurationKeys.TONY_VERSION_INFO_VERSION);
     configurationPropsToSkipCompare.add(TonyConfigurationKeys.TONY_VERSION_INFO_REVISION);
     configurationPropsToSkipCompare.add(TonyConfigurationKeys.TONY_VERSION_INFO_BRANCH);

--- a/tony-core/src/test/java/com/linkedin/tony/TestTonyConfigurationFields.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestTonyConfigurationFields.java
@@ -28,13 +28,13 @@ public class TestTonyConfigurationFields extends TestConfigurationFieldsBase {
     // are determined at runtime. But we still need default values for them in tony-default.xml.
     // So ignore the fact that they exist in tony-default.xml and not in TonyConfigurationKeys.
     xmlPropsToSkipCompare.add(TonyConfigurationKeys.getInstancesKey(Constants.PS_JOB_NAME));
-    xmlPropsToSkipCompare.add(TonyConfigurationKeys.getMemoryKey(Constants.PS_JOB_NAME));
-    xmlPropsToSkipCompare.add(TonyConfigurationKeys.getVCoresKey(Constants.PS_JOB_NAME));
+    xmlPropsToSkipCompare.add(TonyConfigurationKeys.getResourceKey(Constants.PS_JOB_NAME, Constants.MEMORY));
+    xmlPropsToSkipCompare.add(TonyConfigurationKeys.getResourceKey(Constants.PS_JOB_NAME, Constants.VCORES));
     xmlPropsToSkipCompare.add(TonyConfigurationKeys.getResourcesKey(Constants.PS_JOB_NAME));
     xmlPropsToSkipCompare.add(TonyConfigurationKeys.getInstancesKey(Constants.WORKER_JOB_NAME));
-    xmlPropsToSkipCompare.add(TonyConfigurationKeys.getMemoryKey(Constants.WORKER_JOB_NAME));
-    xmlPropsToSkipCompare.add(TonyConfigurationKeys.getVCoresKey(Constants.WORKER_JOB_NAME));
-    xmlPropsToSkipCompare.add(TonyConfigurationKeys.getGPUsKey(Constants.WORKER_JOB_NAME));
+    xmlPropsToSkipCompare.add(TonyConfigurationKeys.getResourceKey(Constants.WORKER_JOB_NAME, Constants.MEMORY));
+    xmlPropsToSkipCompare.add(TonyConfigurationKeys.getResourceKey(Constants.WORKER_JOB_NAME, Constants.VCORES));
+    xmlPropsToSkipCompare.add(TonyConfigurationKeys.getResourceKey(Constants.WORKER_JOB_NAME, Constants.GPUS));
     xmlPropsToSkipCompare.add(TonyConfigurationKeys.getResourcesKey(Constants.WORKER_JOB_NAME));
     configurationPropsToSkipCompare.add(TonyConfigurationKeys.TONY_VERSION_INFO_VERSION);
     configurationPropsToSkipCompare.add(TonyConfigurationKeys.TONY_VERSION_INFO_REVISION);


### PR DESCRIPTION
* Added `tony.task.max-total-X` for setting limit on `X` resource type (e.g.: `tony.task.max-total-gpus`). Added enforcement and unit tests.
* Refactored `getMemoryKey`, `getVCoresKey`, and `getGPUsKey` to `getResourceKey(String jobName, String resource)`
* Fix IDEA setup where generated proto classes weren't being marked as generated sources automatically

Internal Jira: ML-5075