### PR TITLE
Support Horovod in TonY #239

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
@@ -127,7 +127,7 @@ public class TaskExecutor {
     LOG.info("Successfully registered and got cluster spec: " + executor.clusterSpec);
 
     switch (executor.framework) {
-      case TENSORFLOW: {
+      case TENSORFLOW:
         LOG.info("Setting up TensorFlow job...");
         // Set up py4j
         GatewayServer pyServer = new GatewayServer(executor, executor.gatewayServerPort);
@@ -138,8 +138,7 @@ public class TaskExecutor {
         executor.shellEnv.put(Constants.CLUSTER_SPEC, String.valueOf(executor.clusterSpec));
         executor.shellEnv.put(Constants.TF_CONFIG, Utils.constructTFConfig(executor.clusterSpec, executor.jobName, executor.taskIndex));
         break;
-      }
-      case PYTORCH: {
+      case PYTORCH:
         LOG.info("Setting up PyTorch job...");
         String initMethod = Utils.parseClusterSpecForPytorch(executor.clusterSpec);
         if (initMethod == null) {
@@ -150,7 +149,10 @@ public class TaskExecutor {
         executor.shellEnv.put(Constants.RANK, String.valueOf(executor.taskIndex));
         executor.shellEnv.put(Constants.WORLD, String.valueOf(executor.numTasks));
         break;
-      }
+      case HOROVOD:
+        // No extra environment variables needed; horovodrun takes care of setup.
+        // Setting TF_CONFIG causes problems if "chief" isn't set.
+        break;
       default:
         throw new RuntimeException("Unsupported executor framework: " + executor.framework);
     }

--- a/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
@@ -11,7 +11,8 @@ import java.util.List;
 public class TonyConfigurationKeys {
   public enum MLFramework {
     TENSORFLOW,
-    PYTORCH
+    PYTORCH,
+    HOROVOD
   }
 
   private TonyConfigurationKeys() {


### PR DESCRIPTION
Added `HOROVOD` to the `MLFramework` enum. When `tony.application.framework=HOROVOD`, the TaskExecutor will not set `TF_CONFIG`, as `horovodrun` takes care of setup (with MPI's help). Setting `TF_CONFIG` will cause problems if it does not contain `chief`; you'll get a `ValueError: If "cluster" is set in TF_CONFIG, it must have one "chief" node.`.