### PR TITLE
TonY History Server fails to move intermediate application directory to finished directory when application has more than one AM attempt #250

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,8 +155,6 @@ subprojects {
 
   // To avoid conflicts with Play's logback logging
   configurations.all*.exclude group: 'org.slf4j'
-  //configurations.all*.exclude group: 'org.apache.httpcomponents', module: 'httpclient', version: '4.1.2'
-  //configurations.all*.exclude group: 'org.apache.httpcomponents', module: 'httpclient', version: '4.2.5'
 
   publishing {
     publications {

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,12 @@ buildscript {
 
 def hadoopVersion = "2.7.3"
 ext.playVersion = "2.6.20"
-ext.scalaVersion = System.getProperty("scala.binary.version", "2.11")
+ext.scalaVersionFull = System.getProperty("scala.binary.version", "2.11.12")
+ext.scalaVersion = scalaVersionFull
+if (ext.scalaVersionFull.split("\\.").length == 3) {
+  ext.scalaVersion = ext.scalaVersionFull.substring(0, ext.scalaVersionFull.lastIndexOf('.'))
+}
+
 
 ext.deps = [
   azkaban: [
@@ -51,6 +56,7 @@ ext.deps = [
     "commons_io": "commons-io:commons-io:2.4",
     "guava": "com.google.guava:guava:11.0.2",
     "guice": "com.google.inject:guice:3.0",
+    "httpclient": "org.apache.httpcomponents:httpclient:4.5.3",
     "jackson_databind": "com.fasterxml.jackson.core:jackson-databind:2.8.3",
     "jackson_dataformat_yaml": "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.6",
     // Only needed by Hadoop test classes
@@ -62,6 +68,7 @@ ext.deps = [
     "play_guice": "com.typesafe.play:play-guice_$scalaVersion:$playVersion",
     "play_logback": "com.typesafe.play:play-logback_$scalaVersion:$playVersion",
     "py4j": "net.sf.py4j:py4j:0.8.2.1",
+    "scala_compiler": "org.scala-lang:scala-compiler:$scalaVersionFull",
     "sshd": "org.apache.sshd:sshd-core:1.1.0",
     "testng": "org.testng:testng:6.4",
     "text": "org.apache.commons:commons-text:1.4",
@@ -145,6 +152,11 @@ subprojects {
       exclude group: "org.apache.hadoop"
     }
   }
+
+  // To avoid conflicts with Play's logback logging
+  configurations.all*.exclude group: 'org.slf4j'
+  //configurations.all*.exclude group: 'org.apache.httpcomponents', module: 'httpclient', version: '4.1.2'
+  //configurations.all*.exclude group: 'org.apache.httpcomponents', module: 'httpclient', version: '4.2.5'
 
   publishing {
     publications {

--- a/build.gradle
+++ b/build.gradle
@@ -26,12 +26,11 @@ if (ext.scalaVersionFull.split("\\.").length == 3) {
   ext.scalaVersion = ext.scalaVersionFull.substring(0, ext.scalaVersionFull.lastIndexOf('.'))
 }
 
-
 ext.deps = [
   azkaban: [
     "az_core": "com.linkedin.azkaban:az-core:3.58.0",
-    "azkaban_common": "com.linkedin.azkaban:azkaban-common:3.58.0",
     "az_hadoop_jobtype_plugin": "com.linkedin.azkaban:az-hadoop-jobtype-plugin:3.58.0",
+    "azkaban_common": "com.linkedin.azkaban:azkaban-common:3.58.0",
     "azkaban_hadoop_security_plugin": "com.linkedin.azkaban:azkaban-hadoop-security-plugin:3.58.0"
   ],
   hadoop: [
@@ -69,6 +68,7 @@ ext.deps = [
     "play_logback": "com.typesafe.play:play-logback_$scalaVersion:$playVersion",
     "py4j": "net.sf.py4j:py4j:0.8.2.1",
     "scala_compiler": "org.scala-lang:scala-compiler:$scalaVersionFull",
+    "slf4j_api": "org.slf4j:slf4j-api:1.7.25",
     "sshd": "org.apache.sshd:sshd-core:1.1.0",
     "testng": "org.testng:testng:6.4",
     "text": "org.apache.commons:commons-text:1.4",
@@ -152,9 +152,6 @@ subprojects {
       exclude group: "org.apache.hadoop"
     }
   }
-
-  // To avoid conflicts with Play's logback logging
-  configurations.all*.exclude group: 'org.slf4j'
 
   publishing {
     publications {

--- a/tony-cli/build.gradle
+++ b/tony-cli/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'java'
 
 dependencies {
   compile project(':tony-core')
+  compile project(':tony-mini')
   compile project(':tony-proxy')
   testCompile deps.external.mockito
 }

--- a/tony-core/build.gradle
+++ b/tony-core/build.gradle
@@ -10,7 +10,6 @@ dependencies {
   compile(deps.azkaban.az_core) {
     exclude group: 'com.google.guava'
     exclude group: 'com.google.inject'
-//    exclude group: 'org.slf4j'
   }
   compile(deps.azkaban.az_hadoop_jobtype_plugin) { transitive = false }
   compile deps.external.avro
@@ -19,9 +18,7 @@ dependencies {
   compile deps.external.py4j
   compile deps.external.text
   compile deps.external.zip4j
-  compile(deps.hadoop.common) {
-//    exclude group: 'org.slf4j'
-  }
+  compile deps.hadoop.common
   compile deps.hadoop.hdfs
   compile deps.hadoop.yarn_api
   compile deps.hadoop.yarn_client

--- a/tony-core/build.gradle
+++ b/tony-core/build.gradle
@@ -10,17 +10,18 @@ dependencies {
   compile(deps.azkaban.az_core) {
     exclude group: 'com.google.guava'
     exclude group: 'com.google.inject'
+//    exclude group: 'org.slf4j'
   }
-  compile(deps.azkaban.az_hadoop_jobtype_plugin) {
-    exclude group: 'com.google.guava'
-    exclude group: 'com.google.inject'
-  }
+  compile(deps.azkaban.az_hadoop_jobtype_plugin) { transitive = false }
   compile deps.external.avro
+  compile deps.external.httpclient
   compile deps.external.jackson_databind
   compile deps.external.py4j
   compile deps.external.text
   compile deps.external.zip4j
-  compile deps.hadoop.common
+  compile(deps.hadoop.common) {
+//    exclude group: 'org.slf4j'
+  }
   compile deps.hadoop.hdfs
   compile deps.hadoop.yarn_api
   compile deps.hadoop.yarn_client

--- a/tony-core/build.gradle
+++ b/tony-core/build.gradle
@@ -5,31 +5,33 @@ apply plugin: 'java'
 apply plugin: 'com.google.protobuf'
 
 dependencies {
-  compile project(':tony-mini')
-
-  compile(deps.azkaban.az_core) {
-    exclude group: 'com.google.guava'
-    exclude group: 'com.google.inject'
-  }
+  compile(deps.azkaban.az_core) { transitive = false }
   compile(deps.azkaban.az_hadoop_jobtype_plugin) { transitive = false }
-  compile deps.external.avro
+  compile(deps.azkaban.azkaban_common) { transitive = false }
+  compile(deps.external.avro) {
+    exclude group: 'org.slf4j'
+  }
   compile deps.external.httpclient
   compile deps.external.jackson_databind
   compile deps.external.py4j
   compile deps.external.text
   compile deps.external.zip4j
-  compile deps.hadoop.common
+  compile(deps.hadoop.common) {
+    exclude group: 'org.slf4j'
+  }
   compile deps.hadoop.hdfs
   compile deps.hadoop.yarn_api
   compile deps.hadoop.yarn_client
   compile deps.hadoop.yarn_common
 
+  testCompile project(':tony-mini')
   testCompile deps.external.avro
   testCompile deps.external.testng
   testCompile deps.external.mockito
 
   // Only needed by Hadoop test classes
   testRuntime deps.external.junit
+  testRuntime deps.external.slf4j_api
 }
 
 task setupHdfsLib(type: Copy) {

--- a/tony-core/src/main/java/com/linkedin/tony/util/HdfsUtils.java
+++ b/tony-core/src/main/java/com/linkedin/tony/util/HdfsUtils.java
@@ -30,28 +30,6 @@ import org.apache.hadoop.fs.Path;
  */
 public class HdfsUtils {
   private static final Log LOG = LogFactory.getLog(ParserUtils.class);
-  private static final FileStatus[] NO_FILES = {};
-
-  /**
-   * Scan {@code dir} and return a list of files/directories.
-   * @param fs FileSystem object.
-   * @param dir Path of the directory.
-   * @return an array of FileStatus objects representing files/directories in {@code dir}.
-   * Note: result could be an empty array if there {@code dir} is empty.
-   */
-  public static FileStatus[] scanDir(FileSystem fs, Path dir) {
-    String errorMsg;
-    if (dir == null) {
-      return NO_FILES;
-    }
-    try {
-      return fs.listStatus(dir);
-    } catch (IOException e) {
-      errorMsg = "Failed to list files in " + dir;
-      LOG.error(errorMsg, e);
-    }
-    return NO_FILES;
-  }
 
   /**
    * Check to see if HDFS path exists.

--- a/tony-core/src/main/java/com/linkedin/tony/util/ParserUtils.java
+++ b/tony-core/src/main/java/com/linkedin/tony/util/ParserUtils.java
@@ -37,7 +37,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
-import static com.linkedin.tony.util.HdfsUtils.*;
+import static com.linkedin.tony.util.HdfsUtils.pathExists;
 
 
 /**

--- a/tony-core/src/test/java/com/linkedin/tony/util/TestHdfsUtils.java
+++ b/tony-core/src/test/java/com/linkedin/tony/util/TestHdfsUtils.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.HdfsConfiguration;

--- a/tony-core/src/test/java/com/linkedin/tony/util/TestHdfsUtils.java
+++ b/tony-core/src/test/java/com/linkedin/tony/util/TestHdfsUtils.java
@@ -34,36 +34,6 @@ public class TestHdfsUtils {
   }
 
   @Test
-  public void testScanDirEmptyDir() {
-    Path histFolder = new Path(Constants.TONY_CORE_SRC + "test/resources/emptyHistFolder");
-
-    assertEquals(HdfsUtils.scanDir(fs, histFolder).length, 0);
-  }
-
-  @Test
-  public void testScanDirTypical() {
-    Path histFolder = new Path(Constants.TONY_CORE_SRC + "test/resources/typicalHistFolder");
-    FileStatus[] res = HdfsUtils.scanDir(fs, histFolder);
-    assertEquals(res.length, 5);
-  }
-
-  @Test
-  public void testScanDirNullDir() {
-    assertEquals(HdfsUtils.scanDir(fs, null).length, 0);
-  }
-
-  @Test
-  public void testScanDirThrowsException() throws IOException {
-    FileSystem mockFs = mock(FileSystem.class);
-    Path invalidPath = new Path("/invalid/path");
-
-    when(mockFs.listStatus(invalidPath)).thenThrow(new IOException("IO Excpt"));
-
-    assertEquals(HdfsUtils.scanDir(mockFs, invalidPath).length, 0);
-    verify(mockFs).listStatus(invalidPath);
-  }
-
-  @Test
   public void testPathExistsTrue() {
     Path exists = new Path(Constants.TONY_CORE_SRC + "test/resources/file.txt");
 

--- a/tony-history-server/app/controllers/JobsMetadataPageController.java
+++ b/tony-history-server/app/controllers/JobsMetadataPageController.java
@@ -109,11 +109,11 @@ public class JobsMetadataPageController extends Controller {
       return internalServerError("Failed to initialize file system in " + this.getClass());
     }
 
-    FileStatus[] jobDirs;
+    FileStatus[] jobDirs = new FileStatus[0];
     try {
       jobDirs = myFs.listStatus(interm);
     } catch (IOException e) {
-      return internalServerError("Failed to list files in " + interm + ": " + e);
+      LOG.error("Failed to list files in " + interm, e);
     }
     if (jobDirs.length > 0) {
       Map<String, Date> jobsModTime = new HashMap<>();

--- a/tony-history-server/build.gradle
+++ b/tony-history-server/build.gradle
@@ -28,6 +28,9 @@ model {
   }
 }
 
+// To work around conflicts with Play's logback when running tony-history-server tests in IntelliJ
+configurations.all*.exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+
 dependencies {
   play project(':tony-core')
   play deps.external.play_guice

--- a/tony-history-server/build.gradle
+++ b/tony-history-server/build.gradle
@@ -28,15 +28,20 @@ model {
   }
 }
 
+//configurations.all*.exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+
 dependencies {
   play project(':tony-core')
+  play deps.external.httpclient
   play deps.external.play_guice
   play deps.external.play_logback
+  play deps.external.scala_compiler
   play deps.hadoop.common
   play deps.hadoop.yarn_api
 
   playTest deps.external.assertj
   playTest deps.external.awaitility
+  playTest deps.external.httpclient
   playTest deps.external.junit
   playTest deps.external.mockito
 }

--- a/tony-history-server/build.gradle
+++ b/tony-history-server/build.gradle
@@ -28,11 +28,8 @@ model {
   }
 }
 
-//configurations.all*.exclude group: 'org.slf4j', module: 'slf4j-log4j12'
-
 dependencies {
   play project(':tony-core')
-  play deps.external.httpclient
   play deps.external.play_guice
   play deps.external.play_logback
   play deps.external.scala_compiler
@@ -41,7 +38,6 @@ dependencies {
 
   playTest deps.external.assertj
   playTest deps.external.awaitility
-  playTest deps.external.httpclient
   playTest deps.external.junit
   playTest deps.external.mockito
 }

--- a/tony-mini/build.gradle
+++ b/tony-mini/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'java'
 dependencies {
   compile deps.external.avro
   compile deps.external.guava
+  compile deps.external.httpclient
   compile deps.external.jackson_databind
   compile deps.external.jackson_dataformat_yaml
   compile deps.external.objenesis

--- a/tony-mini/build.gradle
+++ b/tony-mini/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'java'
 
+// To work around conflicts with Play's logback when running tony-history-server tests in IntelliJ
+configurations.all*.exclude group: 'org.slf4j'
+
 dependencies {
   compile deps.external.avro
   compile deps.external.guava


### PR DESCRIPTION
Tested manually. All the pending applications in the `intermediate` directory on our cluster are now moved to the `finished` directory.