### PR TITLE
Bump version and update shadeJar to exclude guava dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ ext.deps = [
 
 allprojects {
   group = "com.linkedin.tony"
-  project.version = "0.3.2"
+  project.version = "0.3.3"
 }
 
 task sourcesJar(type: Jar) {
@@ -115,6 +115,7 @@ subprojects {
         exclude(dependency('org.apache.pig:'))
         exclude(dependency('org.apache.spark:'))
         exclude(dependency('org.spark-project:'))
+        exclude(dependency('com.google.guava:'))
       }
       zip64 true
     }

--- a/build.gradle
+++ b/build.gradle
@@ -108,6 +108,7 @@ subprojects {
     shadowJar {
       mergeServiceFiles()
       dependencies {
+        exclude(dependency('com.google.guava:'))
         exclude(dependency('com.sun.jersey:'))
         exclude(dependency('com.sun.jersey.contribs:'))
         exclude(dependency('org.apache.hadoop:'))
@@ -115,7 +116,6 @@ subprojects {
         exclude(dependency('org.apache.pig:'))
         exclude(dependency('org.apache.spark:'))
         exclude(dependency('org.spark-project:'))
-        exclude(dependency('com.google.guava:'))
       }
       zip64 true
     }


### PR DESCRIPTION
Existing com.google.guava in fat jar conflicts with Hadoop 3.3