### PR TITLE
Bump version in preparation for publishing new TonY version with metrics to Maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ ext.deps = [
 
 allprojects {
   group = "com.linkedin.tony"
-  project.version = "0.3.2"
+  project.version = "0.3.3"
 }
 
 task sourcesJar(type: Jar) {


### PR DESCRIPTION
This is so that Dr. Elephant can depend on TonY and the metric-parsing classes in TonY.