### PR TITLE
Fix #261, #262: Refactor moving intermediate to finished to separate thread, create yyyy/mm/dd dirs based on finished time embedded in jhist file instead of directory modification time

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/ApplicationMaster.java
+++ b/tony-core/src/main/java/com/linkedin/tony/ApplicationMaster.java
@@ -476,7 +476,7 @@ public class ApplicationMaster {
     jobDir = new Path(interm, appId);
     // set to `tony` group by default
     // due to inherited permission from parent folder
-    Utils.createDir(fs, jobDir, Constants.PERM770);
+    Utils.createDirIfNotExists(fs, jobDir, Constants.PERM770);
   }
 
   /**

--- a/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
@@ -33,15 +33,20 @@ public class TonyConfigurationKeys {
 
   public static final String OTHER_NAMENODES_TO_ACCESS = TONY_PREFIX + "other.namenodes";
 
-  // History folder configuration
-  public static final String TONY_HISTORY_LOCATION = TONY_PREFIX + "history.location";
+  // History-related configuration
+  public static final String TONY_HISTORY_PREFIX = TONY_PREFIX + "history.";
+
+  public static final String TONY_HISTORY_LOCATION = TONY_HISTORY_PREFIX + "location";
   public static final String DEFAULT_TONY_HISTORY_LOCATION = "/path/to/tony-history";
 
-  public static final String TONY_HISTORY_INTERMEDIATE = TONY_PREFIX + "history.intermediate";
+  public static final String TONY_HISTORY_INTERMEDIATE = TONY_HISTORY_PREFIX + "intermediate";
   public static final String DEFAULT_TONY_HISTORY_INTERMEDIATE = DEFAULT_TONY_HISTORY_LOCATION + "/intermediate";
 
-  public static final String TONY_HISTORY_FINISHED = TONY_PREFIX + "history.finished";
+  public static final String TONY_HISTORY_FINISHED = TONY_HISTORY_PREFIX + "finished";
   public static final String DEFAULT_TONY_HISTORY_FINISHED = DEFAULT_TONY_HISTORY_LOCATION + "/finished";
+
+  public static final String TONY_HISTORY_MOVER_INTERVAL_MS = TONY_HISTORY_PREFIX + "mover-interval-ms";
+  public static final int DEFAULT_TONY_HISTORY_MOVER_INTERVAL_MS = 5 * 60 * 1000;
 
   public static final String TONY_PORTAL_CACHE_MAX_ENTRIES = TONY_PREFIX + "portal.cache.max-entries";
   public static final String DEFAULT_TONY_PORTAL_CACHE_MAX_ENTRIES = "1000";

--- a/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
+++ b/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
@@ -496,7 +496,7 @@ public class Utils {
     return Constants.COMMUNICATION_BACKEND + chiefWorkerAddress;
   }
 
-  public static void createDir(FileSystem fs, Path dir, FsPermission permission) {
+  public static void createDirIfNotExists(FileSystem fs, Path dir, FsPermission permission) {
     String warningMsg;
     try {
       if (!fs.exists(dir)) {

--- a/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
+++ b/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
@@ -500,7 +500,7 @@ public class Utils {
     String warningMsg;
     try {
       if (!fs.exists(dir)) {
-        fs.mkdirs(dir);
+        fs.mkdirs(dir, permission);
         fs.setPermission(dir, permission);
         return;
       }

--- a/tony-core/src/main/resources/tony-default.xml
+++ b/tony-core/src/main/resources/tony-default.xml
@@ -249,6 +249,13 @@
   </property>
 
   <property>
+    <name>tony.history.mover-interval-ms</name>
+    <value>300000</value>
+    <description>Frequency at which to scan the intermediate directory for completed jobs to move to the
+    finished directory.</description>
+  </property>
+
+  <property>
     <description>
       Maximum (approximate) number of cache entries TonY Portal
       will store for each cache (config, metadata, event)

--- a/tony-portal/app/Module.java
+++ b/tony-portal/app/Module.java
@@ -15,5 +15,6 @@ public class Module extends AbstractModule {
     bind(Configuration.class).asEagerSingleton();
     bind(Requirements.class).asEagerSingleton();
     bind(CacheWrapper.class).asEagerSingleton();
+    // add module for moving files from intermediate to finished
   }
 }

--- a/tony-portal/app/Module.java
+++ b/tony-portal/app/Module.java
@@ -2,6 +2,7 @@ import cache.CacheWrapper;
 import com.google.inject.AbstractModule;
 import hadoop.Configuration;
 import hadoop.Requirements;
+import history.HistoryFileMover;
 
 
 /**
@@ -15,6 +16,6 @@ public class Module extends AbstractModule {
     bind(Configuration.class).asEagerSingleton();
     bind(Requirements.class).asEagerSingleton();
     bind(CacheWrapper.class).asEagerSingleton();
-    // add module for moving files from intermediate to finished
+    bind(HistoryFileMover.class).asEagerSingleton();
   }
 }

--- a/tony-portal/app/cache/CacheWrapper.java
+++ b/tony-portal/app/cache/CacheWrapper.java
@@ -20,7 +20,7 @@ public class CacheWrapper {
    * - key: job ID (application_[0-9]+_[0-9]+)
    * - value: JobMetadata object containing all the metadata of the jobs (user, status, etc.)
    */
-  private static Cache<String, JobMetadata> metadataCache;
+  private Cache<String, JobMetadata> metadataCache;
 
   /**
    * configCache
@@ -28,7 +28,7 @@ public class CacheWrapper {
    * - value: List of JobConfig objects. Each JobConfig object
    * represents a {@code property} (name-val-source-final) in config.xml
    */
-  private static Cache<String, List<JobConfig>> configCache;
+  private Cache<String, List<JobConfig>> configCache;
 
   /**
    * eventCache
@@ -36,7 +36,7 @@ public class CacheWrapper {
    * - value: List of JobEvent objects. Each JobEvent object
    * represents an Event in job's jhist
    */
-  private static Cache<String, List<JobEvent>> eventCache;
+  private Cache<String, List<JobEvent>> eventCache;
 
   @Inject
   public CacheWrapper(Config appConf) {
@@ -48,15 +48,15 @@ public class CacheWrapper {
     eventCache = CacheBuilder.newBuilder().maximumSize(maxCacheSz).build();
   }
 
-  public static Cache<String, JobMetadata> getMetadataCache() {
+  public Cache<String, JobMetadata> getMetadataCache() {
     return metadataCache;
   }
 
-  public static Cache<String, List<JobConfig>> getConfigCache() {
+  public Cache<String, List<JobConfig>> getConfigCache() {
     return configCache;
   }
 
-  public static Cache<String, List<JobEvent>> getEventCache() {
+  public Cache<String, List<JobEvent>> getEventCache() {
     return eventCache;
   }
 }

--- a/tony-portal/app/hadoop/Requirements.java
+++ b/tony-portal/app/hadoop/Requirements.java
@@ -42,7 +42,7 @@ public class Requirements {
         errorMsg = dir + " doesn't exist";
         LOG.warn(errorMsg);
         LOG.info("Creating " + dir);
-        Utils.createDir(myFs, dir, perm);
+        Utils.createDirIfNotExists(myFs, dir, perm);
       }
     } catch (IOException e) {
       errorMsg = "Failed to check " + dir + " existence";

--- a/tony-portal/app/hadoop/Requirements.java
+++ b/tony-portal/app/hadoop/Requirements.java
@@ -23,15 +23,15 @@ import utils.ConfigUtils;
 public class Requirements {
   private static final Logger.ALogger LOG = Logger.of(Requirements.class);
 
-  private static String keytabUser;
-  private static String keytabLocation;
+  private String keytabUser;
+  private String keytabLocation;
 
-  private static FileSystem histFs;
-  private static Path histFolder;
-  private static Path interm;
-  private static Path finished;
+  private FileSystem histFs;
+  private Path histFolder;
+  private Path interm;
+  private Path finished;
 
-  public static FileSystem getFileSystem() {
+  public FileSystem getFileSystem() {
     return histFs;
   }
 
@@ -104,11 +104,11 @@ public class Requirements {
     createDirIfNotExists(histFs, finished, Constants.PERM770);
   }
 
-  public static Path getFinishedDir() {
+  public Path getFinishedDir() {
     return finished;
   }
 
-  public static Path getIntermDir() {
+  public Path getIntermDir() {
     return interm;
   }
 }

--- a/tony-portal/app/history/HistoryFileMover.java
+++ b/tony-portal/app/history/HistoryFileMover.java
@@ -69,7 +69,7 @@ public class HistoryFileMover {
         // to compensate.
         path.append(Path.SEPARATOR).append(source.getName());
       }
-      Utils.createDir(fs, new Path(path.toString()), Constants.PERM770);
+      Utils.createDirIfNotExists(fs, new Path(path.toString()), Constants.PERM770);
 
       Path dest = new Path(path.toString());
       LOG.info("Moving " + source + " to " + dest);

--- a/tony-portal/app/history/HistoryFileMover.java
+++ b/tony-portal/app/history/HistoryFileMover.java
@@ -1,0 +1,85 @@
+package history;
+
+import com.linkedin.tony.Constants;
+import com.linkedin.tony.TonyConfigurationKeys;
+import com.linkedin.tony.util.ParserUtils;
+import com.linkedin.tony.util.Utils;
+import com.typesafe.config.Config;
+import hadoop.Requirements;
+import java.io.IOException;
+import java.util.Date;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import play.Logger;
+import utils.ConfigUtils;
+
+
+@Singleton
+public class HistoryFileMover {
+  private static final Logger.ALogger LOG = Logger.of(HistoryFileMover.class);
+
+  private final FileSystem fs;
+  private final Path intermediateDir;
+  private final Path finishedDir;
+
+  @Inject
+  public HistoryFileMover(Config appConf, Requirements requirements) {
+    fs = requirements.getFileSystem();
+    intermediateDir = requirements.getIntermDir();
+    finishedDir = requirements.getFinishedDir();
+
+    ScheduledExecutorService scheduledThreadPool = Executors.newScheduledThreadPool(1);
+
+    LOG.info("Starting background history file mover thread, will run every 5 minutes.");
+    scheduledThreadPool.scheduleAtFixedRate(() -> {
+      FileStatus[] jobDirs = null;
+      try {
+        jobDirs = fs.listStatus(intermediateDir);
+      } catch (IOException e) {
+        LOG.error("Failed to list files in " + intermediateDir, e);
+      }
+      if (jobDirs != null) {
+        moveIntermediateToFinished(fs, jobDirs);
+      }
+    }, 0, ConfigUtils.fetchIntConfigIfExists(appConf, TonyConfigurationKeys.TONY_HISTORY_MOVER_INTERVAL_MS,
+        TonyConfigurationKeys.DEFAULT_TONY_HISTORY_MOVER_INTERVAL_MS), TimeUnit.MILLISECONDS);
+  }
+
+  private void moveIntermediateToFinished(FileSystem fs, FileStatus[] jobDirs) {
+    for (FileStatus jobDir : jobDirs) {
+      String jhistFilePath = ParserUtils.getJhistFilePath(fs, jobDir.getPath());
+      if (jobInProgress(jhistFilePath)) {
+        return;
+      }
+
+      Path source = new Path(jhistFilePath).getParent();
+      StringBuilder path = new StringBuilder(finishedDir.toString());
+      Date endDate = new Date(ParserUtils.getCompletedTimeFromJhistFileName(jhistFilePath));
+      path.append(Path.SEPARATOR).append(ParserUtils.getYearMonthDayDirectory(endDate));
+      if (fs.getScheme().equals("file")) {
+        // On Mac, local filesystem will copy contents of source dir to dest dir, so we have to append the dir name
+        // to compensate.
+        path.append(Path.SEPARATOR).append(source.getName());
+      }
+      Utils.createDir(fs, new Path(path.toString()), Constants.PERM770);
+
+      Path dest = new Path(path.toString());
+      LOG.info("Moving " + source + " to " + dest);
+      try {
+        fs.rename(source, dest);
+      } catch (IOException e) {
+        LOG.error("Failed to move files from intermediate to finished", e);
+      }
+    }
+  }
+
+  private boolean jobInProgress(String jhistFileName) {
+    return !jhistFileName.endsWith(Constants.HISTFILE_SUFFIX);
+  }
+}

--- a/tony-portal/app/history/HistoryFileMover.java
+++ b/tony-portal/app/history/HistoryFileMover.java
@@ -35,8 +35,11 @@ public class HistoryFileMover {
     finishedDir = requirements.getFinishedDir();
 
     ScheduledExecutorService scheduledThreadPool = Executors.newScheduledThreadPool(1);
+    long moverIntervalMs = ConfigUtils.fetchIntConfigIfExists(appConf,
+        TonyConfigurationKeys.TONY_HISTORY_MOVER_INTERVAL_MS,
+        TonyConfigurationKeys.DEFAULT_TONY_HISTORY_MOVER_INTERVAL_MS);
 
-    LOG.info("Starting background history file mover thread, will run every 5 minutes.");
+    LOG.info("Starting background history file mover thread, will run every " + moverIntervalMs + " milliseconds.");
     scheduledThreadPool.scheduleAtFixedRate(() -> {
       FileStatus[] jobDirs = null;
       try {
@@ -47,8 +50,7 @@ public class HistoryFileMover {
       if (jobDirs != null) {
         moveIntermediateToFinished(fs, jobDirs);
       }
-    }, 0, ConfigUtils.fetchIntConfigIfExists(appConf, TonyConfigurationKeys.TONY_HISTORY_MOVER_INTERVAL_MS,
-        TonyConfigurationKeys.DEFAULT_TONY_HISTORY_MOVER_INTERVAL_MS), TimeUnit.MILLISECONDS);
+    }, 0, moverIntervalMs, TimeUnit.MILLISECONDS);
   }
 
   private void moveIntermediateToFinished(FileSystem fs, FileStatus[] jobDirs) {

--- a/tony-portal/app/utils/ConfigUtils.java
+++ b/tony-portal/app/utils/ConfigUtils.java
@@ -26,5 +26,12 @@ public class ConfigUtils {
     return value;
   }
 
+  public static int fetchIntConfigIfExists(Config conf, String key, int defaultVal) {
+    if (conf.hasPath(key)) {
+      return conf.getInt(key);
+    }
+    return defaultVal;
+  }
+
   private ConfigUtils() { }
 }

--- a/tony-portal/conf/application.example.conf
+++ b/tony-portal/conf/application.example.conf
@@ -9,6 +9,9 @@ tony {
     location = "/tmp/tony-history"
     intermediate = "/tmp/tony-history/intermediate"
     finished = "/tmp/tony-history/finished"
+    mover-interval-ms = "5000"
+  }
+  portal {
     cache.max-entries = "2000"
   }
 }

--- a/tony-portal/test/history/HistoryFileMoverTest.java
+++ b/tony-portal/test/history/HistoryFileMoverTest.java
@@ -1,0 +1,80 @@
+package history;
+
+//import com.google.common.io.Files;
+import com.google.common.io.Files;
+import com.linkedin.tony.Constants;
+import com.linkedin.tony.TonyConfigurationKeys;
+import com.linkedin.tony.util.ParserUtils;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import hadoop.Requirements;
+import java.io.File;
+import java.io.IOException;
+import java.util.Calendar;
+import java.util.Date;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.when;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class HistoryFileMoverTest {
+  @Mock
+  Config config;
+
+  @Mock
+  Requirements reqs;
+
+  private static File tempDir;
+  private static File intermediateDir;
+  private static File finishedDir;
+
+  @BeforeClass
+  public static void setup() {
+    tempDir = Files.createTempDir();
+    intermediateDir = new File(tempDir, "intermediate");
+    intermediateDir.mkdirs();
+    finishedDir = new File(tempDir, "finished");
+    finishedDir.mkdirs();
+  }
+
+  @Test
+  public void testMoveIntermediateToFinished() throws IOException, InterruptedException {
+    // Add a completed application in the intermediate dir
+    String appId = "application_123_456";
+    File appDir = new File(intermediateDir, appId);
+    appDir.mkdirs();
+    long endTime = System.currentTimeMillis();
+    File events = new File(appDir, appId + "-123-" + endTime + "-user1-SUCCEEDED." + Constants.HISTFILE_SUFFIX);
+    events.createNewFile();
+
+    // Make sure year/month/day directories created in finished directory are based on finished time set in
+    // jhist file name and NOT based off the application directory's modification time.
+    if (!appDir.setLastModified(0)) {
+      throw new RuntimeException();
+    }
+
+    when(config.hasPath(TonyConfigurationKeys.TONY_HISTORY_MOVER_INTERVAL_MS)).thenReturn(false);
+    when(reqs.getFileSystem()).thenReturn(FileSystem.getLocal(new Configuration()));
+    when(reqs.getIntermDir()).thenReturn(new Path(intermediateDir.getAbsolutePath()));
+    when(reqs.getFinishedDir()).thenReturn(new Path(finishedDir.getAbsolutePath()));
+
+    // start mover
+    new HistoryFileMover(config, reqs);
+    Thread.sleep(250);
+
+    // verify application directory was moved
+    Date endDate = new Date(endTime);
+    File finalDir = new File(finishedDir, ParserUtils.getYearMonthDayDirectory(endDate) + Path.SEPARATOR + appId);
+    Assert.assertFalse(appDir.exists());
+    Assert.assertTrue(finalDir.isDirectory());
+  }
+}


### PR DESCRIPTION
* Added unit test
* Tested locally and on our cluster

To provide more context, previously, the moving of the job directories from the `intermediate` directory to the `finished` directory was being done in `JobsMetadataPageController` every time it was called (whenever the main TonY Portal page was loaded). (This is issue #262.) I moved this code out into a background thread (`HistoryFileMover`).

Also, previously, the `finished` directory folder creation code (which creates `yyyy/mm/dd`) was basing the date off the last modification time of the job directory in `intermediate`, rather than the finish time embedded in the jhist file name itself (`<appId>-<startTime>-<ENDTIME>-<user>-<status>.jhist`). The last modification time is basically when the job started, so it might be several days before the endtime (this was issue #261). I also updated the folder creation code to use the `ENDTIME` embedded in the jhist file name instead.