### PR TITLE
#276, #264, #271: Add TASK_STARTED event, initialize job caches in background, add backward-compatibility for old config.xml file name

### DIFF
--- a/tony-core/src/main/avro/Event.avsc
+++ b/tony-core/src/main/avro/Event.avsc
@@ -4,7 +4,7 @@
   "name": "Event",
   "fields": [
     {"name": "type", "type": "EventType"},
-    {"name": "event", "type": [ "ApplicationInited", "ApplicationFinished", "TaskFinished" ]},
+    {"name": "event", "type": [ "ApplicationInited", "ApplicationFinished", "TaskStarted", "TaskFinished" ]},
     {"name": "timestamp", "type": "long"}
   ]
 }

--- a/tony-core/src/main/avro/EventType.avsc
+++ b/tony-core/src/main/avro/EventType.avsc
@@ -1,5 +1,5 @@
 {
   "namespace": "com.linkedin.tony.events",
   "type": "enum", "name": "EventType",
-  "symbols": [ "APPLICATION_INITED", "APPLICATION_FINISHED", "TASK_FINISHED" ]
+  "symbols": [ "APPLICATION_INITED", "APPLICATION_FINISHED", "TASK_STARTED", "TASK_FINISHED" ]
 }

--- a/tony-core/src/main/avro/TaskStarted.avsc
+++ b/tony-core/src/main/avro/TaskStarted.avsc
@@ -1,0 +1,10 @@
+{
+  "namespace": "com.linkedin.tony.events",
+  "type": "record",
+  "name": "TaskStarted",
+  "fields": [
+    {"name": "taskType", "type": "string"},
+    {"name": "taskIndex", "type": "int"},
+    {"name": "host", "type": "string"}
+  ]
+}

--- a/tony-core/src/main/java/com/linkedin/tony/ApplicationMaster.java
+++ b/tony-core/src/main/java/com/linkedin/tony/ApplicationMaster.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.linkedin.tony.events.TaskFinished;
+import com.linkedin.tony.events.TaskStarted;
 import com.linkedin.tony.models.JobMetadata;
 import com.linkedin.tony.events.ApplicationFinished;
 import com.linkedin.tony.events.ApplicationInited;
@@ -1127,6 +1128,10 @@ public class ApplicationMaster {
       Utils.printTaskUrl(task.getTaskInfo(), LOG);
       nmClientAsync.startContainerAsync(container, ctx);
       taskInfo.setState(TaskStatus.RUNNING);
+      eventHandler.emitEvent(new Event(EventType.TASK_STARTED,
+          new TaskStarted(task.getJobName(), Integer.parseInt(task.getTaskIndex()),
+              container.getNodeHttpAddress().split(":")[0]),
+          System.currentTimeMillis()));
     }
   }
 

--- a/tony-core/src/main/java/com/linkedin/tony/util/ParserUtils.java
+++ b/tony-core/src/main/java/com/linkedin/tony/util/ParserUtils.java
@@ -172,8 +172,8 @@ public class ParserUtils {
   }
 
   /**
-   * Assuming that there's only 1 config.xml file in {@code jobFolderPath},
-   * this function parses config.xml and return a list of {@code JobConfig} objects.
+   * Assuming that there's only 1 config file in {@code jobFolderPath},
+   * this function parses the config file and return a list of {@code JobConfig} objects.
    * @param fs FileSystem object.
    * @param jobFolderPath Path object of job directory.
    * @return a list of {@code JobConfig} objects.
@@ -184,6 +184,16 @@ public class ParserUtils {
     }
 
     Path configFilePath = new Path(jobFolderPath, Constants.TONY_FINAL_XML);
+    try {
+      if (!fs.exists(configFilePath)) {
+        // For backward-compatibility
+        // Remove once everyone is using open-source tony-0.3.5+
+        configFilePath = new Path(jobFolderPath, "config.xml");
+      }
+    } catch (IOException e) {
+      LOG.error("Encountered exception while checking existence of " + configFilePath);
+    }
+
     DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
     List<JobConfig> configs = new ArrayList<>();
 

--- a/tony-core/src/main/java/com/linkedin/tony/util/ParserUtils.java
+++ b/tony-core/src/main/java/com/linkedin/tony/util/ParserUtils.java
@@ -173,7 +173,7 @@ public class ParserUtils {
 
   /**
    * Assuming that there's only 1 config file in {@code jobFolderPath},
-   * this function parses the config file and return a list of {@code JobConfig} objects.
+   * this function parses the config file and returns a list of {@code JobConfig} objects.
    * @param fs FileSystem object.
    * @param jobFolderPath Path object of job directory.
    * @return a list of {@code JobConfig} objects.

--- a/tony-core/src/main/java/com/linkedin/tony/util/ParserUtils.java
+++ b/tony-core/src/main/java/com/linkedin/tony/util/ParserUtils.java
@@ -191,7 +191,7 @@ public class ParserUtils {
         configFilePath = new Path(jobFolderPath, "config.xml");
       }
     } catch (IOException e) {
-      LOG.error("Encountered exception while checking existence of " + configFilePath);
+      LOG.error("Encountered exception while checking existence of " + configFilePath, e);
     }
 
     DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();


### PR DESCRIPTION
* Added `TASK_STARTED` event so I can calculate task duration in Dr. Elephant to calculate MB-sec for resource usage and wastage calculations (#276)
* Updated CacheWrapper's cache initialization code to be done in the background, so that TonY Portal doesn't take a long time to start up initially (#264)
* In #271, the history config file `config.xml` was renamed to `tony-final.xml`. In this PR, I added a check for the presence of `config.xml` for backward compatibility, until all users have migrated to the tony-0.3.5+.

Here's an example of what the TASK_STARTED events look like:
```
 {
  "type" : "TASK_STARTED",
  "event" : {
    "com.linkedin.tony.events.TaskStarted" : {
      "taskType" : "ps",
      "taskIndex" : 0,
      "host" : "my.example2.com"
    }
  },
  "timestamp" : 1557162813941
}
 {
  "type" : "TASK_STARTED",
  "event" : {
    "com.linkedin.tony.events.TaskStarted" : {
      "taskType" : "worker",
      "taskIndex" : 0,
      "host" : "my.example.com"
    }
  },
  "timestamp" : 1557162813976
}
```