### PR TITLE
Fix #279: TonY HistoryFileMover stops after the first job without a history file or that is still in progress

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
+++ b/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
@@ -277,7 +277,9 @@ public class Utils {
     String executablePath = taskCommand.trim().split(" ")[0];
     File executable = new File(executablePath);
     if (!executable.canExecute()) {
-      executable.setExecutable(true);
+      if (!executable.setExecutable(true)) {
+        LOG.error("Failed to make " + executable + " executable");
+      }
     }
 
     // Used for running unit tests in build boxes without Hadoop environment.

--- a/tony-portal/app/history/HistoryFileMover.java
+++ b/tony-portal/app/history/HistoryFileMover.java
@@ -65,7 +65,7 @@ public class HistoryFileMover {
       cacheWrapper.updateCaches(jobDir.getPath());
       String jhistFilePath = ParserUtils.getJhistFilePath(fs, jobDir.getPath());
       if (jhistFilePath == null || jobInProgress(jhistFilePath)) {
-        return;
+        continue;
       }
 
       Path source = new Path(jhistFilePath).getParent();

--- a/tony-portal/app/history/HistoryFileMover.java
+++ b/tony-portal/app/history/HistoryFileMover.java
@@ -51,16 +51,20 @@ public class HistoryFileMover {
         LOG.error("Failed to list files in " + intermediateDir, e);
       }
       if (jobDirs != null) {
-        moveIntermediateToFinished(fs, jobDirs);
+        try {
+          moveIntermediateToFinished(fs, jobDirs);
+        } catch (Exception e) {
+          LOG.error("Encountered exception while moving history directories", e);
+        }
       }
     }, 0, moverIntervalMs, TimeUnit.MILLISECONDS);
   }
 
   private void moveIntermediateToFinished(FileSystem fs, FileStatus[] jobDirs) {
     for (FileStatus jobDir : jobDirs) {
-      String jhistFilePath = ParserUtils.getJhistFilePath(fs, jobDir.getPath());
       cacheWrapper.updateCaches(jobDir.getPath());
-      if (jobInProgress(jhistFilePath)) {
+      String jhistFilePath = ParserUtils.getJhistFilePath(fs, jobDir.getPath());
+      if (jhistFilePath == null || jobInProgress(jhistFilePath)) {
         return;
       }
 

--- a/tony-portal/conf/application.example.conf
+++ b/tony-portal/conf/application.example.conf
@@ -9,7 +9,7 @@ tony {
     location = "/tmp/tony-history"
     intermediate = "/tmp/tony-history/intermediate"
     finished = "/tmp/tony-history/finished"
-    mover-interval-ms = "5000"
+    mover-interval-ms = "300000"
   }
   portal {
     cache.max-entries = "2000"


### PR DESCRIPTION
* Changed a `return` to a `continue` to fix #279
* Added a catch-all Exceptions block to prevent history file mover thread from crashing
* Updated mover-interval-ms in application.example.conf file to match that in tony-default.xml
* Added logging in case setting an executable as executable fails.