### PR TITLE
Fix #281 Automate close and release of staging repo on Nexus

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,31 @@ This will automatically run tests, if want to build without running tests, run:
 
 The jar required to run TonY will be located in `./tony-cli/build/libs/`.
 
+## Publishing (for admins)
+
+Follow [this guide](https://blog.sonatype.com/2010/01/how-to-generate-pgp-signatures-with-maven/) to generate a key pair using GPG. Publish your public key.
+
+Create a Nexus account at https://oss.sonatype.org/ and request access to publish to com.linkedin.tony. Here's an example Jira ticket: https://issues.sonatype.org/browse/OSSRH-47350.
+
+Configure your `~/.gradle/gradle.properties` file:
+
+```
+# signing plugin uses these
+signing.keyId=...
+signing.secretKeyRingFile=/home/<ldap>/.gnupg/secring.gpg
+signing.password=...
+
+# maven repo credentials
+mavenUser=...
+mavenPassword=...
+
+# gradle-nexus-staging-plugin uses these
+nexusUsername=<sameAsMavenUser>
+nexusPassword=<sameAsMavenPassword>
+```
+
+Now you can publish and release artifacts by running `./gradlew publish closeAndReleaseRepository`.
+
 ## Usage
 
 TonY is a Java library, so it is as simple as running a Java program. There are two ways to launch your deep learning jobs with TonY:

--- a/build.gradle
+++ b/build.gradle
@@ -15,8 +15,11 @@ buildscript {
     classpath "com.github.jengelman.gradle.plugins:shadow:2.0.4"
     classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.1"
     classpath "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.14.0"
+    classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.20.0"
   }
 }
+
+apply plugin: 'io.codearte.nexus-staging'
 
 def hadoopVersion = "2.7.3"
 ext.playVersion = "2.6.20"
@@ -77,7 +80,7 @@ ext.deps = [
 
 allprojects {
   group = "com.linkedin.tony"
-  project.version = "0.3.6"
+  project.version = "0.3.7"
 }
 
 task sourcesJar(type: Jar) {


### PR DESCRIPTION
Now you just run:

```
./gradlew publish closeAndReleaseRepository
```

You need to configure the following in your `~/.gradle/gradle.properties`:
```
# signing plugin requires these
signing.keyId=...
signing.secretKeyRingFile=/Users/<user>/.gnupg/secring.gpg
signing.password=...

# maven repo credentials
mavenUser=<yourMavenUserName>
mavenPassword=<yourMavenPassword>

# gradle-nexus-staging-plugin requires these,
# even though they are the same as mavenUser and mavenPassword
nexusUsername=<sameAsYourMavenUserName>
nexusPassword=<sameAsYourMavenPassword>
```

Thanks @mockitoguy for the suggestion.