### PR TITLE
Fix TensorBoard in MNIST distributed TensorFlow example

### DIFF
--- a/tony-examples/mnist-tensorflow/mnist_distributed.py
+++ b/tony-examples/mnist-tensorflow/mnist_distributed.py
@@ -28,7 +28,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from tensorboard.plugins.core import core_plugin
 from tensorflow.examples.tutorials.mnist import input_data
 
 import json

--- a/tony-examples/mnist-tensorflow/mnist_distributed.py
+++ b/tony-examples/mnist-tensorflow/mnist_distributed.py
@@ -178,7 +178,7 @@ def create_model():
 
 
 def start_tensorboard(logdir):
-    tb = tb_program.TensorBoard(plugins=[core_plugin.CorePluginLoader()])
+    tb = tb_program.TensorBoard()
     port = int(os.getenv(TB_PORT_ENV_VAR, 6006))
     tb.configure(logdir=logdir, port=port)
     tb.launch()


### PR DESCRIPTION
TensorBoard loads a bunch of plugins by default:

```
# from tensorboard/default.py
_PLUGINS = [
    core_plugin.CorePluginLoader(),
    beholder_plugin.BeholderPlugin,
    scalars_plugin.ScalarsPlugin,
    custom_scalars_plugin.CustomScalarsPlugin,
    images_plugin.ImagesPlugin,
    audio_plugin.AudioPlugin,
    graphs_plugin.GraphsPlugin,
    distributions_plugin.DistributionsPlugin,
    histograms_plugin.HistogramsPlugin,
    pr_curves_plugin.PrCurvesPlugin,
    projector_plugin.ProjectorPlugin,
    text_plugin.TextPlugin,
    interactive_inference_plugin.InteractiveInferencePlugin,
    profile_plugin.ProfilePluginLoader(),
    debugger_plugin_loader.DebuggerPluginLoader(),
]
```

We had previously specified `CorePluginLoader` in our `TensorBoard()` constructor, causing the other default plugins not to be loaded.

@gogasca FYI