### PR TITLE
Fix #306: TonY Portal start script hangs when run over SSH

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ ext.deps = [
 
 allprojects {
   group = "com.linkedin.tony"
-  project.version = "0.3.9"
+  project.version = "0.3.11"
 }
 
 task sourcesJar(type: Jar) {

--- a/tony-portal/bin/startTonyPortal.sh
+++ b/tony-portal/bin/startTonyPortal.sh
@@ -215,4 +215,6 @@ if [ "$(uname)" = "Darwin" ] && [ "$HOME" = "$PWD" ]; then
 fi
 
 # Run TonY Portal in the background
-nohup ${JAVACMD} ${OPTS} -classpath ${CLASSPATH} play.core.server.ProdServerStart &
+# Redirect all standard streams to prevent hanging when run over SSH.
+# See https://en.wikipedia.org/wiki/Nohup#Overcoming_hanging for details.
+nohup ${JAVACMD} ${OPTS} -classpath ${CLASSPATH} play.core.server.ProdServerStart 2>&1 > nohup.out < /dev/null &


### PR DESCRIPTION
After this change, running startTonyPortal.sh over SSH does not hang -- the SSH session terminates but TonY Portal keeps running.