### PR TITLE
Pass container ApplicationAttemptId to security handling

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/ApplicationMaster.java
+++ b/tony-core/src/main/java/com/linkedin/tony/ApplicationMaster.java
@@ -98,7 +98,6 @@ public class ApplicationMaster {
   /**
    * Metadata + History Server related variables
    */
-  private ApplicationAttemptId appAttemptID = null;
   private String appIdString;
   private FileSystem resourceFs; // FileSystem used to access resources for the job, like jars and zips
   private FileSystem historyFs;  // FileSystem used to write history-related files like config and events.
@@ -414,6 +413,7 @@ public class ApplicationMaster {
 
     if (secureMode) {
       // Set up secret manager for RPC servers
+      ApplicationAttemptId appAttemptID = containerId.getApplicationAttemptId();
       ClientToAMTokenIdentifier identifier = new ClientToAMTokenIdentifier(appAttemptID, user);
       byte[] secret = response.getClientToAMTokenMasterKey().array();
       ClientToAMTokenSecretManager secretManager = new ClientToAMTokenSecretManager(appAttemptID, secret);


### PR DESCRIPTION
We are using TonY on `2.6.0-cdh5.14.2` hadoop distribution.
`ClientToAMTokenIdentifier` has a `write` method, which is triggered by `SecretManager`:
```java
  @Override
  public void write(DataOutput out) throws IOException {
    out.writeLong(this.applicationAttemptId.getApplicationId()
      .getClusterTimestamp());
    out.writeInt(this.applicationAttemptId.getApplicationId().getId());
    out.writeInt(this.applicationAttemptId.getAttemptId());
    this.clientName.write(out);
  }
```
as you can see it calls `(this.applicationAttemptId.getApplicationId().getClusterTimestamp()`, which results in NullPointerException.

This problem is not present on hadoop 2.7.3, (or non-cdh version of hadoop 2.6.0) since write method is using protobuf:
```java
  @Override
  public void write(DataOutput out) throws IOException {
    out.write(proto.toByteArray());
  }
```

Not sure if this change is worth of being merged but maybe it would make things easier for peaple, trying to build TonY against older versions of CDH.

Also it looks somewhat wrong to pass null instead attemptId, since we do have it present on container.

Related: https://github.com/linkedin/TonY/issues/82#issuecomment-504351334
