### PR TITLE
Update Checkstyle to prohibit wildcard imports #347

### DIFF
--- a/ligradle/checkstyle/linkedin-checkstyle.xml
+++ b/ligradle/checkstyle/linkedin-checkstyle.xml
@@ -83,7 +83,7 @@ LinkedIn Java style.
 
     <!-- No imports statements using '*' notation except static imports -->
     <module name="AvoidStarImport">
-      <property name="allowStaticMemberImports" value="true"/>
+      <property name="allowStaticMemberImports" value="false"/>
     </module>
     <!-- Do not import 'sun' packages -->
     <module name="IllegalImport"/>

--- a/tony-cli/src/main/java/com/linkedin/tony/cli/ClusterSubmitter.java
+++ b/tony-cli/src/main/java/com/linkedin/tony/cli/ClusterSubmitter.java
@@ -21,7 +21,11 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.api.records.LocalResourceType;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 
-import static com.linkedin.tony.Constants.*;
+import static com.linkedin.tony.Constants.CORE_SITE_CONF;
+import static com.linkedin.tony.Constants.HADOOP_CONF_DIR;
+import static com.linkedin.tony.Constants.HDFS_SITE_CONF;
+import static com.linkedin.tony.Constants.TONY_FOLDER;
+import static com.linkedin.tony.Constants.TONY_JAR_NAME;
 
 
 /**

--- a/tony-cli/src/main/java/com/linkedin/tony/cli/NotebookSubmitter.java
+++ b/tony-cli/src/main/java/com/linkedin/tony/cli/NotebookSubmitter.java
@@ -26,7 +26,8 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 
-import static com.linkedin.tony.Constants.*;
+import static com.linkedin.tony.Constants.TONY_FOLDER;
+
 
 /**
  * NotebookSubmitter is used to submit a python pex file (for example Jupyter Notebook) to run inside a cluster.

--- a/tony-core/src/main/java/com/linkedin/tony/util/VersionInfo.java
+++ b/tony-core/src/main/java/com/linkedin/tony/util/VersionInfo.java
@@ -13,7 +13,13 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 
-import static com.linkedin.tony.TonyConfigurationKeys.*;
+import static com.linkedin.tony.TonyConfigurationKeys.TONY_VERSION_INFO_BRANCH;
+import static com.linkedin.tony.TonyConfigurationKeys.TONY_VERSION_INFO_CHECKSUM;
+import static com.linkedin.tony.TonyConfigurationKeys.TONY_VERSION_INFO_DATE;
+import static com.linkedin.tony.TonyConfigurationKeys.TONY_VERSION_INFO_REVISION;
+import static com.linkedin.tony.TonyConfigurationKeys.TONY_VERSION_INFO_URL;
+import static com.linkedin.tony.TonyConfigurationKeys.TONY_VERSION_INFO_USER;
+import static com.linkedin.tony.TonyConfigurationKeys.TONY_VERSION_INFO_VERSION;
 
 
 /**

--- a/tony-core/src/test/java/com/linkedin/tony/events/TestEventHandler.java
+++ b/tony-core/src/test/java/com/linkedin/tony/events/TestEventHandler.java
@@ -19,9 +19,13 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static com.linkedin.tony.util.ParserUtils.*;
-import static org.mockito.Mockito.*;
-import static org.testng.Assert.*;
+import static com.linkedin.tony.util.ParserUtils.parseEvents;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 
 
 public class TestEventHandler {

--- a/tony-core/src/test/java/com/linkedin/tony/util/TestHistoryFileUtils.java
+++ b/tony-core/src/test/java/com/linkedin/tony/util/TestHistoryFileUtils.java
@@ -9,7 +9,7 @@ import com.linkedin.tony.models.JobMetadata;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
 
 
 public class TestHistoryFileUtils {

--- a/tony-core/src/test/java/com/linkedin/tony/util/TestUtils.java
+++ b/tony-core/src/test/java/com/linkedin/tony/util/TestUtils.java
@@ -26,8 +26,15 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.testng.annotations.Test;
 
-import static org.mockito.Mockito.*;
-import static org.testng.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
 
 public class TestUtils {
 

--- a/tony-core/src/test/java/com/linkedin/tony/util/gpu/TestGpuDiscoverer.java
+++ b/tony-core/src/test/java/com/linkedin/tony/util/gpu/TestGpuDiscoverer.java
@@ -29,9 +29,6 @@ import org.testng.SkipException;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import static org.mockito.Mockito.*;
-
-
 
 /**
  * Ported from Hadoop 2.9.0


### PR DESCRIPTION
`./gradlew :tony-core:check -x test` passes. Will also let Travis CI run.

Found an unused import as a result of this change!