### PR TITLE
Fix #350: TestTonyE2E testTonyClientCallbackHandler test is flaky

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/client/TaskUpdateListener.java
+++ b/tony-core/src/main/java/com/linkedin/tony/client/TaskUpdateListener.java
@@ -10,5 +10,5 @@ import java.util.Set;
 
 public interface TaskUpdateListener {
     // Called when TonyClient gets a set of taskUrls from TonyAM.
-    public void onTaskInfosUpdated(Set<TaskInfo> taskInfoSet);
+    void onTaskInfosUpdated(Set<TaskInfo> taskInfoSet);
 }

--- a/tony-core/src/main/java/com/linkedin/tony/rpc/TaskInfo.java
+++ b/tony-core/src/main/java/com/linkedin/tony/rpc/TaskInfo.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 
 
 /**
- * Contains the name, index, and URL for a task.
+ * Contains the name, index, URL, and status for a task.
  */
 public class TaskInfo implements Comparable<TaskInfo> {
   private final String name;   // The name (worker or ps) of the task
@@ -24,7 +24,7 @@ public class TaskInfo implements Comparable<TaskInfo> {
     this.url = url;
   }
 
-  public void setState(TaskStatus status) {
+  public void setStatus(TaskStatus status) {
     this.status = status;
   }
 
@@ -75,7 +75,7 @@ public class TaskInfo implements Comparable<TaskInfo> {
   @Override
   public String toString() {
     return String.format(
-        "[TaskInfo] name: %s index: %s url: %s status: %s",
+        "[TaskInfo] name: %s, index: %s, url: %s, status: %s",
         this.name, this.index, this.url, this.status.toString());
   }
 }

--- a/tony-core/src/main/java/com/linkedin/tony/tensorflow/TonySession.java
+++ b/tony-core/src/main/java/com/linkedin/tony/tensorflow/TonySession.java
@@ -233,7 +233,7 @@ public class TonySession {
   }
 
   /**
-   * Refresh task status on each TaskExecutor registers its exit code with AM.
+   * Refresh task status when a TaskExecutor registers its exit code with AM.
    */
   public void onTaskCompleted(String jobName, String jobIndex, int exitCode) {
     LOG.info(String.format("Job %s:%s exited with %d", jobName, jobIndex, exitCode));
@@ -430,17 +430,18 @@ public class TonySession {
     }
 
     synchronized void setExitStatus(int status) {
+      // Only set exit status if it hasn't been set yet
       if (exitStatus == -1) {
         this.exitStatus = status;
         switch (status) {
           case ContainerExitStatus.SUCCESS:
-            taskInfo.setState(TaskStatus.SUCCEEDED);
+            taskInfo.setStatus(TaskStatus.SUCCEEDED);
             break;
           case ContainerExitStatus.KILLED_BY_APPMASTER:
-            taskInfo.setState(TaskStatus.FINISHED);
+            taskInfo.setStatus(TaskStatus.FINISHED);
             break;
           default:
-            taskInfo.setState(TaskStatus.FAILED);
+            taskInfo.setStatus(TaskStatus.FAILED);
             break;
         }
         this.completed = true;

--- a/tony-core/src/main/java/com/linkedin/tony/util/ProtoUtils.java
+++ b/tony-core/src/main/java/com/linkedin/tony/util/ProtoUtils.java
@@ -12,7 +12,7 @@ import com.linkedin.tony.rpc.proto.YarnTensorFlowClusterProtos.GetTaskInfosRespo
 public class ProtoUtils {
   public static TaskInfo taskInfoProtoToTaskInfo(TaskInfoProto taskInfoProto) {
     TaskInfo taskInfo = new TaskInfo(taskInfoProto.getName(), taskInfoProto.getIndex(), taskInfoProto.getUrl());
-    taskInfo.setState(TaskStatus.values()[taskInfoProto.getTaskStatus().ordinal()]);
+    taskInfo.setStatus(TaskStatus.values()[taskInfoProto.getTaskStatus().ordinal()]);
     return taskInfo;
   }
 


### PR DESCRIPTION
Previously, there was a race condition where the PS status might remain as RUNNING:

```
Client                   AM
======                   ==
                         set application final status
get final status
set amRpcClient = null
                         kill PS, set PS status to FINISHED
                         wait for client signal to stop
send stop signal
                         stop
```

In the above example, since PS status is set to FINISHED after amRpcClient is set to null, PS status remains in RUNNING. This is fixed in this PR by updating the order of operations to the following:

```
Client                   AM
======                   ==
                         kill PS, set PS status to FINISHED
                         set application final status
get final status
get task status
set amRpcClient = null
                         wait for client signal to stop
send stop signal
                         stop
```