### PR TITLE
Add action item to error message when user tries to request GPU in a non GPU-supported environment

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
+++ b/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
@@ -184,8 +184,9 @@ public class Utils {
       Method method = resource.getClass().getMethod(Constants.SET_RESOURCE_VALUE_METHOD, String.class, long.class);
       method.invoke(resource, Constants.GPU_URI, gpuCount);
     } catch (NoSuchMethodException nsme) {
-      LOG.error("There is no '" + Constants.SET_RESOURCE_VALUE_METHOD + "' API in this version ("
-              + VersionInfo.getVersion() + ") of YARN", nsme);
+      LOG.error("API to set GPU capability(" + Constants.SET_RESOURCE_VALUE_METHOD + ") is not "
+          + "supported in this version (" + VersionInfo.getVersion() + ") of YARN. Please request"
+          + " CPU instead.");
       throw new RuntimeException(nsme);
     } catch (IllegalAccessException | InvocationTargetException e) {
       LOG.error("Failed to invoke '" + Constants.SET_RESOURCE_VALUE_METHOD + "' method to set GPU resources", e);
@@ -293,7 +294,7 @@ public class Utils {
     ProcessBuilder taskProcessBuilder = new ProcessBuilder("bash", "-c", taskCommand);
     taskProcessBuilder.redirectError(ProcessBuilder.Redirect.INHERIT);
     taskProcessBuilder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
-    // Unset MALLOC_ARENA_MAX for better performance, see https://github.com/linkedin/TonY/issues/346 
+    // Unset MALLOC_ARENA_MAX for better performance, see https://github.com/linkedin/TonY/issues/346
     taskProcessBuilder.environment().remove("MALLOC_ARENA_MAX");
     if (env != null) {
       taskProcessBuilder.environment().putAll(env);

--- a/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
+++ b/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
@@ -185,8 +185,8 @@ public class Utils {
       method.invoke(resource, Constants.GPU_URI, gpuCount);
     } catch (NoSuchMethodException nsme) {
       LOG.error("API to set GPU capability(" + Constants.SET_RESOURCE_VALUE_METHOD + ") is not "
-          + "supported in this version (" + VersionInfo.getVersion() + ") of YARN. Please request"
-          + " CPU instead.");
+          + "supported in this version (" + VersionInfo.getVersion() + ") of YARN. Please "
+          + "do not request GPU.");
       throw new RuntimeException(nsme);
     } catch (IllegalAccessException | InvocationTargetException e) {
       LOG.error("Failed to invoke '" + Constants.SET_RESOURCE_VALUE_METHOD + "' method to set GPU resources", e);


### PR DESCRIPTION
It gives more concrete action item to users who misconfigure their tony job to request GPU in a non-supporting YARN environment so that they can self-help with the job failure. 