### PR TITLE
TaskExecutor should release port immediately prior to launching shell.

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
@@ -101,9 +101,8 @@ public class TaskExecutor {
         if (this.rpcSocket != null) {
           this.rpcSocket.close();
         }
-      }
-      finally {
-        if(this.tbSocket != null) {
+      } finally {
+        if (this.tbSocket != null) {
           this.tbSocket.close();
         }
       }
@@ -168,8 +167,7 @@ public class TaskExecutor {
     TaskExecutor executor = null;
     try {
       executor = createExecutor();
-    }
-    finally {
+    } finally {
       executor.releasePorts();
     }
 

--- a/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
@@ -70,15 +70,15 @@ public class TaskExecutor {
 
   protected TaskExecutor() { }
 
+
   /**
-   * We bind to random ports and then release them, and these are the ports used by the task.
-   * However, there is the possibility that another process grabs the port between when it's released and used again.
+   * We bind to random ports and reserve them up until before the underlying TF process is launched.
+   * @See <a href="https://github.com/linkedin/TonY/issues/365">this issue</a> for details.
    */
   private void setupPorts() throws IOException {
     // Reserve a rpcSocket rpcPort.
     this.rpcSocket = new ServerSocket(0);
     this.rpcPort = this.rpcSocket.getLocalPort();
-    this.rpcSocket.close();
     LOG.info("Reserved rpcPort: " + this.rpcPort);
 
     // With Estimator API, there is a separate lone "chief" task that runs TensorBoard.
@@ -86,17 +86,24 @@ public class TaskExecutor {
     if (isChief) {
       this.tbSocket = new ServerSocket(0);
       this.tbPort = this.tbSocket.getLocalPort();
-      this.tbSocket.close();
       this.registerTensorBoardUrl();
       this.shellEnv.put(Constants.TB_PORT, String.valueOf(this.tbPort));
       LOG.info("Reserved tbPort: " + this.tbPort);
     }
   }
 
-  public static void main(String[] unused) throws Exception {
-    LOG.info("TaskExecutor is running..");
-    TaskExecutor executor = new TaskExecutor();
+  private void releasePorts() throws IOException {
+    if (this.rpcSocket != null) {
+      this.rpcSocket.close();
+    }
 
+    if(this.tbSocket != null) {
+      this.tbSocket.close();
+    }
+  }
+
+  private static TaskExecutor createExecutor() throws Exception {
+    TaskExecutor executor = new TaskExecutor();
     executor.initConfigs();
     Utils.extractResources();
 
@@ -105,7 +112,7 @@ public class TaskExecutor {
 
     LOG.info("Setting up metrics RPC client, connecting to: " + executor.amHost + ":" + executor.metricsRPCPort);
     executor.metricsProxy = RPC.getProxy(MetricsRpc.class, RPC.getProtocolVersion(MetricsRpc.class),
-            new InetSocketAddress(executor.amHost, executor.metricsRPCPort), executor.yarnConf);
+        new InetSocketAddress(executor.amHost, executor.metricsRPCPort), executor.yarnConf);
     executor.scheduledThreadPool.scheduleAtFixedRate(
         new TaskMonitor(executor.jobName, executor.taskIndex, executor.yarnConf, executor.tonyConf, executor.metricsProxy),
         0,
@@ -114,6 +121,8 @@ public class TaskExecutor {
 
     executor.setupPorts();
     executor.clusterSpec = executor.registerAndGetClusterSpec();
+    executor.releasePorts();
+
     if (executor.clusterSpec == null) {
       LOG.error("Failed to register worker with AM.");
       throw new Exception("Failed to register worker with AM.");
@@ -146,6 +155,19 @@ public class TaskExecutor {
       default:
         throw new RuntimeException("Unsupported executor framework: " + executor.framework);
     }
+    return executor;
+  }
+  public static void main(String[] unused) throws Exception {
+    LOG.info("TaskExecutor is running..");
+    TaskExecutor executor = null;
+    try {
+      executor = createExecutor();
+    }
+    finally {
+      executor.releasePorts();
+    }
+
+    assert executor != null;
 
     int exitCode = Utils.executeShell(executor.taskCommand, executor.timeOut, executor.shellEnv);
     // START - worker skew testing:

--- a/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
@@ -92,14 +92,22 @@ public class TaskExecutor {
     }
   }
 
+  /**
+   * Release the reserved ports if any. This method has to be invoked after ports are
+   * created.
+   * @throws IOException
+   */
   private void releasePorts() throws IOException {
-    if (this.rpcSocket != null) {
-      this.rpcSocket.close();
-    }
-
-    if(this.tbSocket != null) {
-      this.tbSocket.close();
-    }
+      try {
+        if (this.rpcSocket != null) {
+          this.rpcSocket.close();
+        }
+      }
+      finally {
+        if(this.tbSocket != null) {
+          this.tbSocket.close();
+        }
+      }
   }
 
   private static TaskExecutor createExecutor() throws Exception {
@@ -121,7 +129,6 @@ public class TaskExecutor {
 
     executor.setupPorts();
     executor.clusterSpec = executor.registerAndGetClusterSpec();
-    executor.releasePorts();
 
     if (executor.clusterSpec == null) {
       LOG.error("Failed to register worker with AM.");

--- a/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
@@ -93,8 +93,7 @@ public class TaskExecutor {
   }
 
   /**
-   * Release the reserved ports if any. This method has to be invoked after ports are
-   * created.
+   * Release the reserved ports if any. This method has to be invoked after ports are created.
    * @throws IOException
    */
   private void releasePorts() throws IOException {

--- a/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.hadoop.yarn.api.records.ContainerId;
 
 import static com.linkedin.tony.TonyConfigurationKeys.MLFramework;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Content that we want to run in the containers. TaskExecutor will register itself with AM and fetch cluster spec from
@@ -166,12 +167,12 @@ public class TaskExecutor {
     LOG.info("TaskExecutor is running..");
     TaskExecutor executor = null;
     try {
-      executor = createExecutor();
+      executor = requireNonNull(createExecutor());
     } finally {
-      executor.releasePorts();
+      if (executor != null) {
+        executor.releasePorts();
+      }
     }
-
-    assert executor != null;
 
     int exitCode = Utils.executeShell(executor.taskCommand, executor.timeOut, executor.shellEnv);
     // START - worker skew testing:


### PR DESCRIPTION
Problem description: https://github.com/linkedin/TonY/issues/365.

Unit tests to be added as follow up.