### PR TITLE
Fix race condition in ApplicationMaster.stopRunningContainers method.

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/ApplicationMaster.java
+++ b/tony-core/src/main/java/com/linkedin/tony/ApplicationMaster.java
@@ -695,7 +695,7 @@ public class ApplicationMaster {
     if (allContainers != null) {
       for (Container container : allContainers) {
         TonyTask task = session.getTask(container.getId());
-        if (!task.isCompleted()) {
+        if (task != null && !task.isCompleted()) {
           nmClientAsync.stopContainerAsync(container.getId(), container.getNodeId());
         }
       }


### PR DESCRIPTION
Fixes race condition manifested by `NullPointerException`:
```
2019-10-12 06:31:25 INFO  Utils:513 - Completed all 2 tracked tasks. 
2019-10-12 06:31:25 INFO  TonySession:298 - Session completed with no job failures, setting final status SUCCEEDED. 
2019-10-12 06:31:25 INFO  ApplicationMaster:348 - Result: true, retry count: 0 
Exception in thread "main" java.lang.NullPointerException 
	at com.linkedin.tony.ApplicationMaster.stopRunningContainers(ApplicationMaster.java:698) 
	at com.linkedin.tony.ApplicationMaster.stop(ApplicationMaster.java:670) 
	at com.linkedin.tony.ApplicationMaster.run(ApplicationMaster.java:358) 
	at com.linkedin.tony.ApplicationMaster.main(ApplicationMaster.java:297) 
```