### PR TITLE
Add support for shiv/pex python packages

### DIFF
--- a/tony-azkaban/src/main/java/com/linkedin/tony/azkaban/TonyJob.java
+++ b/tony-azkaban/src/main/java/com/linkedin/tony/azkaban/TonyJob.java
@@ -158,7 +158,7 @@ public class TonyJob extends HadoopJavaJob {
     }
 
     String interpreterPath = getJobProps().getString(TonyJobArg.INTERPRETER_PATH.azPropName, null);
-    if (interpreterPath != null ) {
+    if (interpreterPath != null) {
       args.append(" " + TonyJobArg.INTERPRETER_PATH.tonyParamName + " " + interpreterPath);
     }
 

--- a/tony-azkaban/src/main/java/com/linkedin/tony/azkaban/TonyJob.java
+++ b/tony-azkaban/src/main/java/com/linkedin/tony/azkaban/TonyJob.java
@@ -157,6 +157,11 @@ public class TonyJob extends HadoopJavaJob {
       args.append(" " + TonyJobArg.PYTHON_VENV.tonyParamName + " " + pythonVenv);
     }
 
+    String interpreterPath = getJobProps().getString(TonyJobArg.INTERPRETER_PATH.azPropName, null);
+    if (interpreterPath != null ) {
+      args.append(" " + TonyJobArg.INTERPRETER_PATH.tonyParamName + " " + interpreterPath);
+    }
+
     String executes = getJobProps().getString(TonyJobArg.EXECUTES.azPropName, null);
     if (executes != null) {
       args.append(" " + TonyJobArg.EXECUTES.tonyParamName + " " + executes);

--- a/tony-azkaban/src/main/java/com/linkedin/tony/azkaban/TonyJobArg.java
+++ b/tony-azkaban/src/main/java/com/linkedin/tony/azkaban/TonyJobArg.java
@@ -12,7 +12,9 @@ public enum TonyJobArg {
   PYTHON_BINARY_PATH("python_binary_path"),
   PYTHON_VENV("python_venv"),
   EXECUTES("executes"),
-  SRC_DIR("src_dir");
+  SRC_DIR("src_dir"),
+  INTERPRETER_PATH("interpreter_path");
+
 
   TonyJobArg(String azPropName) {
     this.azPropName = azPropName;

--- a/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
+++ b/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
@@ -313,7 +313,6 @@ public class Utils {
       taskProcess.waitFor();
     }
     return taskProcess.exitValue();
-
   }
 
   public static String getCurrentHostName() {

--- a/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
+++ b/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
@@ -264,8 +264,13 @@ public class Utils {
     opts.addOption("hdfs_classpath", true, "Path to jars on HDFS for workers.");
 
     // Python env
+    // This will be deprecated in future because zip of virtualenv is not a reliable way to package python code.
+    // Going forward, we should try to use the generic "interpreter_path" option which can be a path to pex or shiv
+    // executable for Python code.
     opts.addOption("python_binary_path", true, "The relative path to python binary.");
     opts.addOption("python_venv", true, "The python virtual environment zip.");
+
+    opts.addOption("interpreter_path", true, "Path to the interpreter which will be used to invoke the file in executes.");
 
     return opts;
   }

--- a/tony-core/src/test/java/com/linkedin/tony/TestApplicationMaster.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestApplicationMaster.java
@@ -38,5 +38,16 @@ public class TestApplicationMaster {
     expected = "venv/Python/bin/python "
         + "src/main/python/my_awesome_script.py --input_dir hdfs://default/foo/bar";
     Assert.assertEquals(actual, expected);
+
+    // interpreterPath is set
+    actual = TonyClient.buildTaskCommand("./project.pyz", "mnist.py", "--input_dir hdfs://default/foo/bar");
+    expected = "./project.pyz mnist.py --input_dir hdfs://default/foo/bar";
+    Assert.assertEquals(actual, expected);
+
+    // interpreterPath is null
+    actual = TonyClient.buildTaskCommand(null, "mnist.py", "--input_dir hdfs://default/foo/bar");
+    expected = "mnist.py --input_dir hdfs://default/foo/bar";
+    Assert.assertEquals(actual, expected);
+
   }
 }

--- a/tony-core/src/test/java/com/linkedin/tony/TestTonyE2E.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestTonyE2E.java
@@ -461,6 +461,8 @@ public class TestTonyE2E  {
         "--executes", "ls",
         "--shell_env", "TEST1=test",
         "--container_env", "TEST2=test",
+        "--interpreter_path", "tony-core/src/test/resources/test.zip",
+        "--conf", "tony.ps.instances=1",
         "--conf", "tony.worker.command=cat",
         "--conf", "tony.containers.resources=tony-core/src/test/resources/test.zip"
     });
@@ -471,7 +473,7 @@ public class TestTonyE2E  {
     String path = client.processFinalTonyConf();
     Configuration finalConf = new Configuration();
     finalConf.addResource(new Path(path));
-    assertEquals(finalConf.get(TonyConfigurationKeys.getContainerExecuteCommandKey()), "ls");
+    assertEquals(finalConf.get(TonyConfigurationKeys.getContainerExecuteCommandKey()), "tony-core/src/test/resources/test.zip ls");
     assertEquals(finalConf.get(TonyConfigurationKeys.CONTAINER_LAUNCH_ENV), "TEST2=test");
     assertEquals(finalConf.get(TonyConfigurationKeys.EXECUTION_ENV), "TEST1=test");
     assertEquals(finalConf.get(TonyConfigurationKeys.getExecuteCommandKey("worker")), "cat");
@@ -480,5 +482,4 @@ public class TestTonyE2E  {
     assertTrue(finalConf.get(TonyConfigurationKeys.getContainerResourcesKey()).contains("test.zip"));
     assertTrue(finalConf.get(TonyConfigurationKeys.getContainerResourcesKey()).contains("common.zip"));
   }
-
 }


### PR DESCRIPTION
Zipping Venv is not a very reliable way of packaging python as it ships interpreter in the zip file which may or may not work with .so available on the target host. So add support for running executables from other package managers like shiv or pex.