### PR TITLE
Add support for shiv/pex python packages

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
@@ -204,6 +204,15 @@ public class TonyClient implements AutoCloseable {
           new Path(pythonVenv), Constants.PYTHON_VENV_ZIP, tonyConf, fs, LocalResourceType.FILE, TonyConfigurationKeys.getContainerResourcesKey());
     }
 
+    // If the user has provided python binary path without the python virtual env
+    // and the binary path exists, then upload it.
+    if (pythonVenv == null && pythonBinaryPath != null) {
+      File pythonBinaryFile = new File(pythonBinaryPath);
+      if (pythonBinaryFile.exists()) {
+        Utils.uploadFileAndSetConfResources(appResourcesPath,
+            new Path(pythonBinaryPath), pythonBinaryPath, tonyConf, fs, LocalResourceType.FILE, TonyConfigurationKeys.getContainerResourcesKey());
+      }
+    }
 
     URL coreSiteUrl = yarnConf.getResource(Constants.CORE_SITE_CONF);
     if (coreSiteUrl != null) {

--- a/tony-core/src/test/java/com/linkedin/tony/TestTonyE2E.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestTonyE2E.java
@@ -459,6 +459,7 @@ public class TestTonyE2E  {
     TonyClient client = spy(this.client);
     client.init(new String[]{
         "--executes", "ls",
+        "--python_binary_path", "/non-existent/path",
         "--shell_env", "TEST1=test",
         "--container_env", "TEST2=test",
         "--conf", "tony.worker.command=cat",
@@ -471,7 +472,9 @@ public class TestTonyE2E  {
     String path = client.processFinalTonyConf();
     Configuration finalConf = new Configuration();
     finalConf.addResource(new Path(path));
-    assertEquals(finalConf.get(TonyConfigurationKeys.getContainerExecuteCommandKey()), "ls");
+    // Python binary path is only uploaded if it exists. If it doesn't we still let it go through as user may have provided
+    // it in some other way and this keeps the change backward compatible.
+    assertEquals(finalConf.get(TonyConfigurationKeys.getContainerExecuteCommandKey()), "/non-existent/path ls");
     assertEquals(finalConf.get(TonyConfigurationKeys.CONTAINER_LAUNCH_ENV), "TEST2=test");
     assertEquals(finalConf.get(TonyConfigurationKeys.EXECUTION_ENV), "TEST1=test");
     assertEquals(finalConf.get(TonyConfigurationKeys.getExecuteCommandKey("worker")), "cat");


### PR DESCRIPTION
Zipping Venv is not a very reliable way of packaging python as it ships interpreter in the zip file which may or may not work with .so available on the target host. So add support for running executables from other package managers like shiv or pex.

