### PR TITLE
Exposing container diagnostic information for failed task to Tony

### DIFF
--- a/tony-core/src/main/avro/TaskFinished.avsc
+++ b/tony-core/src/main/avro/TaskFinished.avsc
@@ -6,6 +6,7 @@
     {"name": "taskType", "type": "string"},
     {"name": "taskIndex", "type": "int"},
     {"name": "status", "type":  "string"},
-    {"name": "metrics", "type": {"type": "array", "items": "Metric"}}
+    {"name": "metrics", "type": {"type": "array", "items": "Metric"}},
+    {"name": "containerDiagnostic", "type": ["null","string"], "default": null, "doc":  "Container error information"}
   ]
 }

--- a/tony-core/src/main/java/com/linkedin/tony/ApplicationMaster.java
+++ b/tony-core/src/main/java/com/linkedin/tony/ApplicationMaster.java
@@ -953,7 +953,7 @@ public class ApplicationMaster {
   class NMCallbackHandler implements NMClientAsync.CallbackHandler {
     @Override
     public void onContainerStopped(ContainerId containerId) {
-      processFinishedContainer(containerId, ContainerExitStatus.KILLED_BY_APPMASTER);
+      processFinishedContainer(containerId, ContainerExitStatus.KILLED_BY_APPMASTER, "KILLED_BY_APPMASTER");
     }
 
     @Override
@@ -994,13 +994,14 @@ public class ApplicationMaster {
             + ", state = " + containerStatus.getState()
             + ", exitStatus = " + exitStatus);
         String diagnostics = containerStatus.getDiagnostics();
+        String errorInformation = null;
         if (ContainerExitStatus.SUCCESS != exitStatus) {
+          errorInformation = diagnostics;
           LOG.error(diagnostics);
         } else {
           LOG.info(diagnostics);
         }
-
-        processFinishedContainer(containerStatus.getContainerId(), exitStatus);
+        processFinishedContainer(containerStatus.getContainerId(), exitStatus, errorInformation);
       }
     }
 
@@ -1145,7 +1146,7 @@ public class ApplicationMaster {
     mainThread.interrupt();
   }
 
-  private void processFinishedContainer(ContainerId containerId, int exitStatus) {
+  private void processFinishedContainer(ContainerId containerId, int exitStatus, String diagnosticMessage) {
     TonyTask task = session.getTask(containerId);
     if (task != null) {
       // Ignore tasks from past sessions.
@@ -1156,11 +1157,19 @@ public class ApplicationMaster {
       LOG.info("Container " + containerId + " for task " + task + " finished with exitStatus " + exitStatus + ".");
       session.onTaskCompleted(task.getJobName(), task.getTaskIndex(), exitStatus);
       scheduler.registerDependencyCompleted(task.getJobName());
-      eventHandler.emitEvent(new Event(EventType.TASK_FINISHED,
-          new TaskFinished(task.getJobName(), Integer.parseInt(task.getTaskIndex()),
-              task.getTaskInfo().getStatus().toString(),
-              metricsRpcServer.getMetrics(task.getJobName(), Integer.parseInt(task.getTaskIndex()))),
-          System.currentTimeMillis()));
+      if (ContainerExitStatus.SUCCESS != exitStatus) {
+        eventHandler.emitEvent(new Event(EventType.TASK_FINISHED,
+            new TaskFinished(task.getJobName(), Integer.parseInt(task.getTaskIndex()),
+                task.getTaskInfo().getStatus().toString(),
+                metricsRpcServer.getMetrics(task.getJobName(), Integer.parseInt(task.getTaskIndex())),
+                diagnosticMessage), System.currentTimeMillis()));
+      } else {
+        eventHandler.emitEvent(new Event(EventType.TASK_FINISHED,
+            new TaskFinished(task.getJobName(), Integer.parseInt(task.getTaskIndex()),
+                task.getTaskInfo().getStatus().toString(),
+                metricsRpcServer.getMetrics(task.getJobName(), Integer.parseInt(task.getTaskIndex())), "NA"),
+            System.currentTimeMillis()));
+      }
 
       // Detect if an untracked task has crashed to prevent application hangups.
       if (!Utils.isJobTypeTracked(task.getJobName(), tonyConf) && task.isFailed()) {

--- a/tony-core/src/test/java/com/linkedin/tony/util/TestParserUtils.java
+++ b/tony-core/src/test/java/com/linkedin/tony/util/TestParserUtils.java
@@ -191,13 +191,15 @@ public class TestParserUtils {
         .getContainerID());
     assertNull(JobLog.convertEventToJobLog(applicationEvents.get(3), new JobLogMetaData(yarnConf, "testuser"))
         .getContainerID());
+    //mock(ApplicationMaster)
   }
+
 
   private List<Event> eventBuilder() {
     ApplicationInited applicationInited = new ApplicationInited("fakeid123", 2, "fakehost2", "fakecontainerID");
     TaskStarted taskStarted = new TaskStarted("faketasktype", 3, "fakehost3", "fakecontainerID1");
     java.util.List<com.linkedin.tony.events.Metric> dummymetrics = new ArrayList<>();
-    TaskFinished taskFinished = new TaskFinished("fasktasktype", 4, "false", dummymetrics);
+    TaskFinished taskFinished = new TaskFinished("fasktasktype", 4, "false", dummymetrics, "File not found");
     ApplicationFinished applicationFinished = new ApplicationFinished("fakeid123", 4, 3, dummymetrics);
     List<Event> applicationEvents = new ArrayList<>();
     Event applicationInitedEvent = new Event(EventType.APPLICATION_INITED, applicationInited, 1L);


### PR DESCRIPTION
Currently Tony History files doesn't contain the diagnostic information for the failed task . Its really helpful for user to see the diagnostic information of failed container on Tony Portal . This functionality is very similar to exception excerpts in JHS / SHS . 

TonyHistoryPortal after the changes 

![image](https://user-images.githubusercontent.com/16147255/74656209-b1ab2280-51b3-11ea-9a69-04451a596a85.png)
