### PR TITLE
Add JOB_ID to environment variable in container

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/ApplicationMaster.java
+++ b/tony-core/src/main/java/com/linkedin/tony/ApplicationMaster.java
@@ -1093,6 +1093,7 @@ public class ApplicationMaster {
       Map<String, String> dockerEnv = Utils.getContainerEnvForDocker(tonyConf, jobName);
       containerLaunchEnv.putAll(dockerEnv);
       containerLaunchEnv.put(Constants.JOB_NAME, jobName);
+      containerLaunchEnv.put(Constants.JOB_ID, appIdString);
       containerLaunchEnv.put(Constants.TASK_INDEX, taskIndex);
       containerLaunchEnv.put(Constants.TASK_NUM, String.valueOf(session.getTotalTrackedTasks()));
       if (session.isChief(jobName, taskIndex)) {

--- a/tony-core/src/main/java/com/linkedin/tony/Constants.java
+++ b/tony-core/src/main/java/com/linkedin/tony/Constants.java
@@ -62,6 +62,7 @@ public class Constants {
   // Distributed TensorFlow job name, e.g. "ps" or "worker",
   // as per https://www.tensorflow.org/deploy/distributed
   public static final String JOB_NAME = "JOB_NAME";
+  public static final String JOB_ID = "JOB_ID";
   public static final String SESSION_ID = "SESSION_ID";
   public static final String PREPROCESSING_JOB = "PREPROCESSING_JOB";
 


### PR DESCRIPTION
`JOB_ID` here is application id of yarn.
In order to use MLflow or other python packages to track each run is related to which yarn application,
we set JOB_ID to container env, so that we could log this variable in python program.