### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,11 @@ The `src/` folder would contain all your training script. The `tony.xml` is used
         <value>3g</value>
       </property>
       <property>
-        <name>tony.application.docker.enabled</name>
+        <name>tony.docker.enabled</name>
         <value>true</value>
       </property>
       <property>
-        <name>tony.application.docker.image</name>
+        <name>tony.docker.containers.image</name>
         <value>YOUR_DOCKER_IMAGE_NAME</value>
       </property>
     </configuration>


### PR DESCRIPTION
When we run Tony in docker containers we should configure `tony.docker.enabled` instead of   `tony.application.docker.enabled`
https://github.com/linkedin/TonY/blob/408f67c6569136742125f21557223d53922d6ce7/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java#L232-L235
`tony.application.docker.image` should chnage to  `tony.docker.containers.image`
https://github.com/linkedin/TonY/blob/408f67c6569136742125f21557223d53922d6ce7/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java#L262-L264