### PR TITLE
Add github actions based build workflow

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,21 @@
+name: master
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew clean build --stacktrace --info


### PR DESCRIPTION
This commit adds support for building Tony in Github actions. This will run on PRs and Pushing into the master. I have it passing in my git repo and can be checked under actions tab:

https://github.com/goyalankit/TonY/actions

Tested it with push to master and pull request.