### PR TITLE
fix publication of tony-portal distribution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,6 +159,7 @@ subprojects {
   publishing {
     publications {
       mavenJava(MavenPublication) {
+        artifactId = "${project.name}"
         if (project.name.equals("tony-portal")) {
           artifact source: "$buildDir/distributions/${project.name}-${project.version}.zip", builtBy: { tasks.createPlayBinaryZipDist }
         } else {

--- a/build.gradle
+++ b/build.gradle
@@ -159,10 +159,13 @@ subprojects {
   publishing {
     publications {
       mavenJava(MavenPublication) {
-        from components.java
-        artifactId = "${project.name}"
-        artifact sourcesJar
-        artifact javadocJar
+        if (project.name.equals("tony-portal")) {
+          artifact source: "$buildDir/distributions/${project.name}-${project.version}.zip", builtBy: { tasks.createPlayBinaryZipDist }
+        } else {
+          from components.java
+          artifact sourcesJar
+          artifact javadocJar
+        }
         if (project.name.equals("tony-cli")) {
           artifact shadowJar
         }


### PR DESCRIPTION
To address issue #441 

Tested with 'gradle publishToMavenLocal' and 'gradle publish' to Nexus Staging repo. Both worked fine.