### PR TITLE
*Adds default option for containerID in avro schema*

### DIFF
--- a/tony-core/src/main/avro/ApplicationInited.avsc
+++ b/tony-core/src/main/avro/ApplicationInited.avsc
@@ -6,6 +6,6 @@
     {"name": "applicationId", "type": "string"},
     {"name": "numTasks", "type": "int"},
     {"name": "host", "type": "string"},
-    {"name": "containerID", "type": "string", "doc":  "Container  id"}
+    {"name": "containerID", "type": ["null","string"], "default": null, "doc":  "Container  id"}
   ]
 }

--- a/tony-core/src/main/avro/TaskStarted.avsc
+++ b/tony-core/src/main/avro/TaskStarted.avsc
@@ -6,6 +6,6 @@
     {"name": "taskType", "type": "string"},
     {"name": "taskIndex", "type": "int"},
     {"name": "host", "type": "string"},
-    {"name": "containerID", "type": "string", "doc":  "Container  id"}
+    {"name": "containerID", "type": ["null","string"], "default": null, "doc":  "Container  id"}
   ]
 }


### PR DESCRIPTION
Applications were becoming backloged in the intermediate
folder in the tony history directory and not moving to the
finished folder due to an inability to locate an
expected value for the containerID. As this is a recently
added field in the avro schema and not all applications
may surface this correctly, a default option needed to
be added in order to account for these instances.