### PR TITLE
Fix retries if the failure is due to missed heartbeats.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ ext.deps = [
 
 allprojects {
   group = "com.linkedin.tony"
-  project.version = "0.3.27"
+  project.version = "0.3.28"
 }
 
 task sourcesJar(type: Jar) {

--- a/tony-core/src/main/java/com/linkedin/tony/ApplicationMaster.java
+++ b/tony-core/src/main/java/com/linkedin/tony/ApplicationMaster.java
@@ -558,8 +558,9 @@ public class ApplicationMaster {
                + container.getNodeId().getHost());
     }
 
-    // Reset the flag to track untracked processes.
+    // Reset the flags that indicate failure.
     untrackedTaskFailed = false;
+    taskHasMissesHB = false;
 
     // Reset session
     session = sessionBuilder.build();


### PR DESCRIPTION
During a retry, missed heartbeat variable is not set. So if the previous retry failed due to a heartbeat failures, Tony will keep failing since the variable is not reset.

Here's an example log:
All the 10 retries failed quickly with the same error:
```
$ cat t | grep 'ERROR' | grep 'Application failed'
2020-06-26 08:44:27 ERROR ApplicationMaster:598 - Application failed due to missed heartbeats
2020-06-26 08:44:52 ERROR ApplicationMaster:598 - Application failed due to missed heartbeats
2020-06-26 08:44:53 ERROR ApplicationMaster:598 - Application failed due to missed heartbeats
2020-06-26 08:44:56 ERROR ApplicationMaster:598 - Application failed due to missed heartbeats
2020-06-26 08:44:57 ERROR ApplicationMaster:598 - Application failed due to missed heartbeats
2020-06-26 08:44:58 ERROR ApplicationMaster:598 - Application failed due to missed heartbeats
2020-06-26 08:45:00 ERROR ApplicationMaster:598 - Application failed due to missed heartbeats
2020-06-26 08:45:02 ERROR ApplicationMaster:598 - Application failed due to missed heartbeats
2020-06-26 08:45:03 ERROR ApplicationMaster:598 - Application failed due to missed heartbeats
2020-06-26 08:45:05 ERROR ApplicationMaster:598 - Application failed due to missed heartbeats
2020-06-26 08:45:07 ERROR ApplicationMaster:598 - Application failed due to missed heartbeats
```