### PR TITLE
Hold reserved ports till task finishes to avoid possible port conflict in TaskExecutor

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
@@ -70,6 +70,8 @@ public class TaskExecutor {
   private final ScheduledExecutorService scheduledThreadPool = Executors.newScheduledThreadPool(2);
   private int numFailedHBAttempts = 0;
   private MLFramework framework;
+  // Port numbers range from 0 to 65535, but 0 to 1023 are reserved for privileged
+  // services and designated as well-known ports.
   public static final Range<Integer> PORT_RANGE = Range.between(1024, 65535);
   public static final String PORT_FILE_PREFIX = "___port___";
   public static final java.nio.file.Path PORT_FILE_DIR = Paths.get(System.getProperty("java.io"

--- a/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
@@ -12,7 +12,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
-import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -102,7 +101,7 @@ public class TaskExecutor {
       // in case task executor is killed abruptly, delete port file
       file.deleteOnExit();
       boolean fileCreated = file.createNewFile();
-      if(!fileCreated) {
+      if (!fileCreated) {
         LOG.debug("Port " + port + " is not available");
         serverSocket.close();
         return null;

--- a/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
@@ -70,7 +70,6 @@ public class TaskExecutor {
   private final ScheduledExecutorService scheduledThreadPool = Executors.newScheduledThreadPool(2);
   private int numFailedHBAttempts = 0;
   private MLFramework framework;
-  // port range [1, 65535]
   public static final Range<Integer> PORT_RANGE = Range.between(1, 65535);
   public static final String PORT_FILE_PREFIX = "___port___";
   public static final java.nio.file.Path PORT_FILE_DIR = Paths.get(System.getProperty("java.io"
@@ -270,6 +269,7 @@ public class TaskExecutor {
       executor = requireNonNull(createExecutor());
     } finally {
       if (executor != null) {
+        // release ports so that subsequent taskCommand process can consume them.
         executor.releasePorts();
       }
     }

--- a/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
@@ -71,7 +71,7 @@ public class TaskExecutor {
   private int numFailedHBAttempts = 0;
   private MLFramework framework;
   // Port numbers range from 0 to 65535, but 0 to 1023 are reserved for privileged
-  // services and designated as well-known ports.
+  // services and designated as well-known ports in most linux system.
   public static final Range<Integer> PORT_RANGE = Range.between(1024, 65535);
   public static final String PORT_FILE_PREFIX = "___port___";
   public static final java.nio.file.Path PORT_FILE_DIR = Paths.get(System.getProperty("java.io"

--- a/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
@@ -70,7 +70,7 @@ public class TaskExecutor {
   private final ScheduledExecutorService scheduledThreadPool = Executors.newScheduledThreadPool(2);
   private int numFailedHBAttempts = 0;
   private MLFramework framework;
-  public static final Range<Integer> PORT_RANGE = Range.between(1, 65535);
+  public static final Range<Integer> PORT_RANGE = Range.between(1024, 65535);
   public static final String PORT_FILE_PREFIX = "___port___";
   public static final java.nio.file.Path PORT_FILE_DIR = Paths.get(System.getProperty("java.io"
       + ".tmpdir"));

--- a/tony-core/src/test/java/com/linkedin/tony/TestTaskExecutor.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestTaskExecutor.java
@@ -97,7 +97,7 @@ public class TestTaskExecutor {
       Assert.assertNull(anotherSocket);
     } finally {
       Files.deleteIfExists(getPortFile(serverSocket.getLocalPort()));
-      if(anotherSocket != null) {
+      if (anotherSocket != null) {
         anotherSocket.close();
       }
     }

--- a/tony-core/src/test/java/com/linkedin/tony/TestTaskExecutor.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestTaskExecutor.java
@@ -48,6 +48,12 @@ public class TestTaskExecutor {
   }
 
   @Test
+  public void testPortRangeIsValid() {
+    Assert.assertEquals(TaskExecutor.PORT_RANGE.getMinimum().intValue(), 1);
+    Assert.assertEquals(TaskExecutor.PORT_RANGE.getMaximum().intValue(), 65536);
+  }
+
+  @Test
   public void testCreateServerSocketSuccess() throws IOException {
     TaskExecutor taskExecutor = new TaskExecutor();
     int port = this.getAvailablePort();

--- a/tony-core/src/test/java/com/linkedin/tony/TestTaskExecutor.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestTaskExecutor.java
@@ -91,12 +91,15 @@ public class TestTaskExecutor {
     ServerSocket serverSocket = taskExecutor.createServerSocket(port);
     serverSocket.close();
     Assert.assertTrue(Files.exists(getPortFile(serverSocket.getLocalPort())));
+    ServerSocket anotherSocket = null;
     try {
-      ServerSocket anotherSocket = taskExecutor.createServerSocket(port);
+      anotherSocket = taskExecutor.createServerSocket(port);
       Assert.assertNull(anotherSocket);
     } finally {
       Files.deleteIfExists(getPortFile(serverSocket.getLocalPort()));
+      if(anotherSocket != null) {
+        anotherSocket.close();
+      }
     }
   }
-
 }

--- a/tony-core/src/test/java/com/linkedin/tony/TestTaskExecutor.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestTaskExecutor.java
@@ -49,7 +49,7 @@ public class TestTaskExecutor {
 
   @Test
   public void testPortRangeIsValid() {
-    Assert.assertEquals(TaskExecutor.PORT_RANGE.getMinimum().intValue(), 1);
+    Assert.assertEquals(TaskExecutor.PORT_RANGE.getMinimum().intValue(), 1024);
     Assert.assertEquals(TaskExecutor.PORT_RANGE.getMaximum().intValue(), 65535);
   }
 

--- a/tony-core/src/test/java/com/linkedin/tony/TestTaskExecutor.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestTaskExecutor.java
@@ -50,7 +50,7 @@ public class TestTaskExecutor {
   @Test
   public void testPortRangeIsValid() {
     Assert.assertEquals(TaskExecutor.PORT_RANGE.getMinimum().intValue(), 1);
-    Assert.assertEquals(TaskExecutor.PORT_RANGE.getMaximum().intValue(), 65536);
+    Assert.assertEquals(TaskExecutor.PORT_RANGE.getMaximum().intValue(), 65535);
   }
 
   @Test


### PR DESCRIPTION
Even with fix in https://github.com/linkedin/TonY/pull/366, task executor is still subject to **port conflict** where port could be grabbed by other process on the host before task process launches and after ports are closed. To address such conflict, following mechanism is applied:
Task executor will iterate over defined port range and check a port's availability based on 1. socket API **and** 2. the existence of corresponding port file. If socket can be created with the port and corresponding port file doesn't exist, a temp file tracking that port will be created under a shared directory(specified by _java.io.tmpdir_) and that port will be reserved for the process. The file will be deleted upon the process finishes.

A similar approach is also mentioned in https://github.com/linkedin/TonY/issues/365#issuecomment-529116493.

Note as mentioned in https://github.com/linkedin/TonY/pull/453#issuecomment-655914054, if other non-tony processes grab the port during the gap after ports are closed and before task process launches, it's still subject to the risk of port conflict.