### PR TITLE
Release tensorboard port before tensorflow process starts regardless of port reuse

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
@@ -226,10 +226,10 @@ public class TaskExecutor {
     // details.
     if (executor != null) {
       LOG.info("Releasing reserved port(s) before launching tensorflow process.");
-      if (!executor.isReusingPort()) {
-        executor.releasePorts();
-      } else {
+      if (executor.isReusingPort()) {
         executor.releasePort(executor.tbPort);
+      } else {
+        executor.releasePorts();
       }
     }
 

--- a/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
@@ -225,7 +225,7 @@ public class TaskExecutor {
     // launched. See <a href="https://github.com/linkedin/TonY/issues/365">this issue</a> for
     // details.
     if (executor != null) {
-      LOG.info("Releasing reserved ports before launching tensorflow process.");
+      LOG.info("Releasing reserved port(s) before launching tensorflow process.");
       if (!executor.isReusingPort()) {
         executor.releasePorts();
       } else {

--- a/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
@@ -87,10 +87,17 @@ public class TaskExecutor {
     // With Estimator API, there is a separate lone "chief" task that runs TensorBoard.
     // With the low-level distributed API, worker 0 runs TensorBoard.
     if (isChief) {
-      this.tbPort = requireNonNull(allocatePort());
+      this.tbPort = requireNonNull(EphemeralPort.create());
       this.registerTensorBoardUrl();
       this.shellEnv.put(Constants.TB_PORT, String.valueOf(this.tbPort.getPort()));
       LOG.info("Reserved tbPort: " + this.tbPort.getPort());
+    }
+  }
+
+
+  private void releasePort(ServerPort port) throws Exception {
+    if (port != null) {
+      port.close();
     }
   }
 
@@ -99,13 +106,9 @@ public class TaskExecutor {
    */
   private void releasePorts() throws Exception {
     try {
-      if (this.rpcPort != null) {
-        this.rpcPort.close();
-      }
+      this.releasePort(this.rpcPort);
     } finally {
-      if (this.tbPort != null) {
-        this.tbPort.close();
-      }
+      this.releasePort(this.tbPort);
     }
   }
 
@@ -221,9 +224,14 @@ public class TaskExecutor {
     // If not reusing port, then reserve them up until before the underlying TF process is
     // launched. See <a href="https://github.com/linkedin/TonY/issues/365">this issue</a> for
     // details.
-    if (executor != null && !executor.isReusingPort()) {
+    if (executor != null ) {
       LOG.info("Releasing reserved ports before launching tensorflow process.");
-      executor.releasePorts();
+      if (!executor.isReusingPort()) {
+        executor.releasePorts();
+      }
+      else {
+        executor.releasePort(executor.tbPort);
+      }
     }
 
     try {
@@ -237,7 +245,7 @@ public class TaskExecutor {
     } finally {
       if (executor.isReusingPort()) {
         LOG.info("Tensorflow process exited, releasing reserved ports.");
-        executor.releasePorts();
+        executor.releasePort(executor.rpcPort);
       }
     }
   }

--- a/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TaskExecutor.java
@@ -224,12 +224,11 @@ public class TaskExecutor {
     // If not reusing port, then reserve them up until before the underlying TF process is
     // launched. See <a href="https://github.com/linkedin/TonY/issues/365">this issue</a> for
     // details.
-    if (executor != null ) {
+    if (executor != null) {
       LOG.info("Releasing reserved ports before launching tensorflow process.");
       if (!executor.isReusingPort()) {
         executor.releasePorts();
-      }
-      else {
+      } else {
         executor.releasePort(executor.tbPort);
       }
     }


### PR DESCRIPTION
#456 introduced port reuse based on the fact that tensorflow's gRPC server has the corresponding port reuse option. But it's not true for tensorboard(TB), so TB's port cannot be reused and needs to be released before tensorflow process regardless if user is using port reuse or not.