### PR TITLE
Make TonY client log layout more organized

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
@@ -13,6 +13,7 @@ import com.linkedin.tony.client.CallbackHandler;
 import com.linkedin.tony.client.TaskUpdateListener;
 import com.linkedin.tony.rpc.TaskInfo;
 import com.linkedin.tony.rpc.impl.ApplicationRpcClient;
+import com.linkedin.tony.rpc.impl.TaskStatus;
 import com.linkedin.tony.security.TokenCache;
 import com.linkedin.tony.tensorflow.JobContainerRequest;
 import com.linkedin.tony.util.HdfsUtils;
@@ -31,13 +32,14 @@ import java.nio.ByteBuffer;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -50,6 +52,7 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -135,7 +138,6 @@ public class TonyClient implements AutoCloseable {
   private Path appResourcesPath;
   private int hbInterval;
   private int maxHbMisses;
-  private boolean isTaskUrlsPrinted = false;
 
   private CallbackHandler callbackHandler;
   private CopyOnWriteArrayList<TaskUpdateListener> listeners = new CopyOnWriteArrayList<>();
@@ -950,7 +952,23 @@ public class TonyClient implements AutoCloseable {
       FinalApplicationStatus finalApplicationStatus = report.getFinalApplicationStatus();
       initRpcClientAndLogAMUrl(report);
 
-      updateTaskInfos();
+      boolean isFirstTimePrint = taskInfos.isEmpty();
+      boolean isTaskUpdated = updateTaskInfoAndReturn();
+      if (isTaskUpdated) {
+        if (isFirstTimePrint) {
+          // if it's first time printing tasks, log detailed info of the tasks, including
+          // name, index, status, and URL.
+          LOG.info("------  Application (re)starts, status of ALL tasks ------");
+          logTaskInfo(taskInfos);
+        } else {
+          // if tasks are already logged before, then only print task name, index, and status. NOT
+          // print URL which is too long to be user-friendly in the driver log. Users can
+          // always find the URL of corresponding task they are interested from previously
+          // printed logs.
+          LOG.info("------ Task Status Updated ------");
+          logSimplifiedTaskInfo(taskInfos);
+        }
+      }
 
       if (YarnApplicationState.KILLED == appState) {
         LOG.warn("Application " + appId.getId() + " was killed. YarnState: " + appState + ". "
@@ -962,7 +980,9 @@ public class TonyClient implements AutoCloseable {
       }
 
       if (YarnApplicationState.FINISHED == appState || YarnApplicationState.FAILED == appState) {
-        updateTaskInfos();
+        updateTaskInfoAndReturn();
+        LOG.info("-----  Application finished, status of ALL tasks -----");
+        logSimplifiedTaskInfo(taskInfos);
         LOG.info("Application " + appId.getId() + " finished with YarnState=" + appState
             + ", DSFinalStatus=" + finalApplicationStatus + ", breaking monitoring loop.");
         String tonyPortalUrl =
@@ -992,36 +1012,127 @@ public class TonyClient implements AutoCloseable {
     return result;
   }
 
-  private void updateTaskInfos() {
-    try {
-      if (amRpcClient != null) {
+
+  /**
+   * Sorts tasks based on status, name and index.
+   * Task order follows {@link TaskStatus#STATUS_SORTED_BY_ATTENTION}. For tasks of same status,
+   * sorts them based on name, then index.
+   * An example of output:
+   * [TaskInfo] name: ps, index: 1, url: url status: FAILED
+   * [TaskInfo] name: worker, index: 3, url: url status: FAILED
+   * [TaskInfo] name: worker, index: 1, url: url status: SUCCEEDED
+   * [TaskInfo] name: worker, index: 5, url: url status: FINISHED
+   * [TaskInfo] name: ps, index: 0, url: url status: RUNNING
+   * [TaskInfo] name: worker, index: 0, url: url status: RUNNING
+   * [TaskInfo] name: worker, index: 2, url: url status: RUNNING
+   * [TaskInfo] name: worker, index: 4, url: url status: RUNNING
+   */
+  @VisibleForTesting
+  static List<TaskInfo> sortTaskInfo(Collection<TaskInfo> tasks) {
+    List<TaskInfo> sortedAllTaskInfo = new ArrayList<>(tasks);
+    Collections.sort(sortedAllTaskInfo, (o1, o2) -> {
+      if (o1.getStatus().equals(o2.getStatus())) {
+        return o1.compareTo(o2);
+      } else {
+        return TaskStatus.STATUS_SORTED_BY_ATTENTION.indexOf(o1.getStatus()) - TaskStatus.STATUS_SORTED_BY_ATTENTION.indexOf(o2.getStatus());
+      }
+    });
+
+    return sortedAllTaskInfo;
+  }
+
+  /**
+   * Logs task info. Task info will be sorted by status, then name, then index in the log.
+   * Task order follows {@link TaskStatus#STATUS_SORTED_BY_ATTENTION}. For tasks of same status,
+   * sorts them based on name, then index.
+   * An example of output:
+   * [TaskInfo] name: ps, index: 1, url: url status: FAILED
+   * [TaskInfo] name: worker, index: 3, url: url status: FAILED
+   * [TaskInfo] name: worker, index: 1, url: url status: SUCCEEDED
+   * [TaskInfo] name: worker, index: 5, url: url status: FINISHED
+   * [TaskInfo] name: ps, index: 0, url: url status: RUNNING
+   * [TaskInfo] name: worker, index: 0, url: url status: RUNNING
+   * [TaskInfo] name: worker, index: 2, url: url status: RUNNING
+   * [TaskInfo] name: worker, index: 4, url: url status: RUNNING
+   */
+  private static void logTaskInfo(Collection<TaskInfo> tasks) {
+    List<TaskInfo> sortedTasks = sortTaskInfo(tasks);
+    String log = "%s, %s, %s, %s";
+    for (TaskInfo taskInfo : sortedTasks) {
+      LOG.info(String.format(log, taskInfo.getName(), taskInfo.getIndex(), taskInfo.getStatus(),
+          taskInfo.getUrl()));
+    }
+  }
+
+  /**
+   * Merge tasks by task names.
+   * E.g:
+   * input:
+   *     TaskInfo("ps", "0", "url")
+   *     TaskInfo("ps", "1", "url")
+   *     TaskInfo("worker", "0", "url")
+   *     TaskInfo("worker", "1", "url")
+   * returns:
+   *     [TaskInfo] name: ps {1, 2}, worker {0, 1}
+   *
+   * @param taskInfoByStatus
+   */
+  @VisibleForTesting
+  static String mergeTasks(List<TaskInfo> taskInfoByStatus) {
+    StringBuffer toBePrinted = new StringBuffer();
+    List<String> taskGroup = new ArrayList<>();
+    for (int i = 0; i < taskInfoByStatus.size(); i++) {
+      taskGroup.add(taskInfoByStatus.get(i).getIndex());
+      if (i == taskInfoByStatus.size() - 1 || !taskInfoByStatus.get(i).getName().equals(taskInfoByStatus.get(i + 1).getName())) {
+        toBePrinted.append(taskInfoByStatus.get(i).getName() + " [" + StringUtils.join(taskGroup,
+            ", ") + "]" + " ");
+        taskGroup.clear();
+      }
+    }
+    return toBePrinted.toString();
+  }
+
+  /**
+   * Logs task name, index and status. Intentionally skip logging task URL to avoid info
+   * overwhelming.
+   * Log looks like following (group by status, and then sorted the tasks by task name then index):
+   * Status FAILED: ps {0, 1, 2} worker {1}
+   * Status RUNNING: ps {3} worker {0}
+   * @param tasks
+   */
+  private static void logSimplifiedTaskInfo(Collection<TaskInfo> tasks) {
+    List<TaskInfo> sortedTaskInfo = sortTaskInfo(tasks);
+
+    for (TaskStatus status : TaskStatus.STATUS_SORTED_BY_ATTENTION) {
+      List<TaskInfo> taskInfoPerStatus =
+          sortedTaskInfo.stream().filter(c -> c.getStatus().equals(status)).collect(Collectors.toList());
+      if (!taskInfoPerStatus.isEmpty()) {
+        LOG.info(status + ": " + mergeTasks(taskInfoPerStatus));
+      }
+    }
+  }
+
+  /**
+   * Updates task info and returns whether any task is updated.
+   */
+  private boolean updateTaskInfoAndReturn() {
+    boolean taskUpdated = false;
+    if (amRpcClient != null) {
+      try {
         Set<TaskInfo> receivedInfos = amRpcClient.getTaskInfos();
-        Set<TaskInfo> taskInfoDiff = receivedInfos.stream()
-                .filter(taskInfo -> !taskInfos.contains(taskInfo))
-                .collect(Collectors.toSet());
+        taskUpdated = !taskInfos.equals(receivedInfos);
         // If task status is changed, invoke callback for all listeners.
-        if (!taskInfoDiff.isEmpty()) {
-          for (TaskInfo taskInfo : taskInfoDiff) {
-            LOG.info("Task status updated: " + taskInfo);
-          }
+        if (taskUpdated) {
           for (TaskUpdateListener listener : listeners) {
             listener.onTaskInfosUpdated(receivedInfos);
           }
           taskInfos = receivedInfos;
         }
-
-        // Query AM for taskInfos if taskInfos is empty.
-        if (amRpcServerInitialized && !isTaskUrlsPrinted) {
-          if (!taskInfos.isEmpty()) {
-            // Print TaskUrls
-            new TreeSet<>(taskInfos).forEach(task -> Utils.printTaskUrl(task, LOG));
-            isTaskUrlsPrinted = true;
-          }
-        }
+      } catch (IOException | YarnException e) {
+        LOG.error("Errors on calling AM to update task infos.");
       }
-    } catch (IOException | YarnException e) {
-      LOG.error("Errors on calling AM to update task infos.");
     }
+    return taskUpdated;
   }
 
   private void initRpcClientAndLogAMUrl(ApplicationReport report) throws IOException {

--- a/tony-core/src/main/java/com/linkedin/tony/rpc/TaskInfo.java
+++ b/tony-core/src/main/java/com/linkedin/tony/rpc/TaskInfo.java
@@ -46,10 +46,15 @@ public class TaskInfo implements Comparable<TaskInfo> {
 
   @Override
   public int compareTo(TaskInfo other) {
-    if (!this.name.equals(other.name)) {
-      return this.name.compareTo(other.name);
+    if (this.getStatus().equals(other.getStatus())) {
+      if (!this.name.equals(other.name)) {
+        return this.name.compareTo(other.name);
+      }
+
+      return Integer.valueOf(this.index).compareTo(Integer.valueOf(other.index));
+    } else {
+      return TaskStatus.STATUS_SORTED_BY_ATTENTION.indexOf(this.getStatus()) - TaskStatus.STATUS_SORTED_BY_ATTENTION.indexOf(other.getStatus());
     }
-    return Integer.valueOf(this.index).compareTo(Integer.valueOf(other.index));
   }
 
   @Override

--- a/tony-core/src/main/java/com/linkedin/tony/rpc/impl/TaskStatus.java
+++ b/tony-core/src/main/java/com/linkedin/tony/rpc/impl/TaskStatus.java
@@ -4,11 +4,18 @@
  */
 package com.linkedin.tony.rpc.impl;
 
+import com.google.common.collect.ImmutableList;
+
 public enum TaskStatus {
     NEW,
     READY,
     RUNNING,
     FAILED,
     SUCCEEDED,
-    FINISHED   // for untracked tasks killed by the AM
+    FINISHED; // for untracked tasks killed by the AM
+    // If new status is added, please also add it to {@link STATUS_SORTED_BY_VISIBILITY}
+
+    // Ordered status from most attention-worthy to least
+    public static final ImmutableList<TaskStatus> STATUS_SORTED_BY_ATTENTION =
+        ImmutableList.of(FAILED, SUCCEEDED, FINISHED, RUNNING, NEW, READY);
 }

--- a/tony-core/src/test/java/com/linkedin/tony/TestTaskStatus.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestTaskStatus.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2020 LinkedIn Corporation. All rights reserved. Licensed under the BSD-2 Clause
+ * license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.tony;
+
+import static org.testng.Assert.assertEquals;
+
+import com.linkedin.tony.rpc.impl.TaskStatus;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import org.testng.annotations.Test;
+
+public class TestTaskStatus {
+
+  @Test
+  public void testTaskStatus() {
+    // Verify what TaskStatus.STATUS_SORTED_BY_VISIBILITY returns is complete
+
+    assertEquals(TaskStatus.values().length, TaskStatus.STATUS_SORTED_BY_ATTENTION.size());
+
+    Set<TaskStatus> taskStatusSet1 = new HashSet<>(Arrays.asList(TaskStatus.values()));
+    Set<TaskStatus> taskStatusSet2 = new HashSet<>(TaskStatus.STATUS_SORTED_BY_ATTENTION);
+
+    assertEquals(taskStatusSet1, taskStatusSet2);
+  }
+}

--- a/tony-core/src/test/java/com/linkedin/tony/TestTonyClient.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestTonyClient.java
@@ -4,6 +4,12 @@
  */
 package com.linkedin.tony;
 
+import com.linkedin.tony.rpc.TaskInfo;
+import com.linkedin.tony.rpc.impl.TaskStatus;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import org.apache.commons.cli.ParseException;
 import org.apache.hadoop.conf.Configuration;
 import org.testng.annotations.Test;
@@ -115,5 +121,66 @@ public class TestTonyClient {
     assertEquals(
         applicationTags,
         client.getTonyConf().get(TonyConfigurationKeys.APPLICATION_TAGS));
+  }
+
+  @Test
+  public void testSortingTasks() {
+    List<TaskInfo> tasks = new ArrayList<>();
+    TaskInfo task1 = new TaskInfo("worker", "0", "url");
+    task1.setStatus(TaskStatus.RUNNING);
+    TaskInfo task2 = new TaskInfo("worker", "1", "url");
+    task2.setStatus(TaskStatus.SUCCEEDED);
+    TaskInfo task3 = new TaskInfo("worker", "2", "url");
+    task3.setStatus(TaskStatus.RUNNING);
+    TaskInfo task4 = new TaskInfo("worker", "3", "url");
+    task4.setStatus(TaskStatus.FAILED);
+    TaskInfo task5 = new TaskInfo("worker", "4", "url");
+    task5.setStatus(TaskStatus.RUNNING);
+    TaskInfo task6 = new TaskInfo("worker", "5", "url");
+    task6.setStatus(TaskStatus.FINISHED);
+    TaskInfo task7 = new TaskInfo("ps", "0", "url");
+    task7.setStatus(TaskStatus.RUNNING);
+    TaskInfo task8 = new TaskInfo("ps", "1", "url");
+    task8.setStatus(TaskStatus.FAILED);
+
+    tasks.add(task1);
+    tasks.add(task2);
+    tasks.add(task3);
+    tasks.add(task4);
+    tasks.add(task5);
+    tasks.add(task6);
+    tasks.add(task7);
+    tasks.add(task8);
+
+    Collections.shuffle(tasks);
+    List<TaskInfo> expected = new ArrayList<>(Arrays.asList(task8, task4, task2, task6, task7,
+        task1, task3, task5));
+
+    int i = 0;
+    for (TaskInfo task : TonyClient.sortTaskInfo(tasks)) {
+      assertEquals(task, expected.get(i++));
+    }
+  }
+
+  @Test
+  public void testMergeTasks() {
+    List<TaskInfo> tasks = new ArrayList<>();
+    tasks.add(new TaskInfo("ps", "1", "url"));
+    tasks.add(new TaskInfo("ps", "2", "url"));
+    tasks.add(new TaskInfo("ps", "3", "url"));
+    tasks.add(new TaskInfo("worker", "4", "url"));
+    tasks.add(new TaskInfo("worker", "5", "url"));
+    tasks.add(new TaskInfo("worker", "6", "url"));
+    assertEquals(TonyClient.mergeTasks(tasks).trim(), "ps {1, 2, 3} worker {4, 5, 6}");
+  }
+
+  @Test
+  public void testMergeTasksSingleElement() {
+    List<TaskInfo> tasks = new ArrayList<>();
+    tasks.add(new TaskInfo("ps", "1", "url"));
+    assertEquals(TonyClient.mergeTasks(tasks).trim(), "ps {1}");
+
+    tasks.add(new TaskInfo("worker", "1", "url"));
+    assertEquals(TonyClient.mergeTasks(tasks).trim(), "ps {1} worker {1}");
   }
 }

--- a/tony-core/src/test/java/com/linkedin/tony/TestTonyClient.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestTonyClient.java
@@ -156,8 +156,9 @@ public class TestTonyClient {
     List<TaskInfo> expected = new ArrayList<>(Arrays.asList(task8, task4, task2, task6, task7,
         task1, task3, task5));
 
+    Collections.sort(tasks);
     int i = 0;
-    for (TaskInfo task : TonyClient.sortTaskInfo(tasks)) {
+    for (TaskInfo task : tasks) {
       assertEquals(task, expected.get(i++));
     }
   }
@@ -171,16 +172,16 @@ public class TestTonyClient {
     tasks.add(new TaskInfo("worker", "4", "url"));
     tasks.add(new TaskInfo("worker", "5", "url"));
     tasks.add(new TaskInfo("worker", "6", "url"));
-    assertEquals(TonyClient.mergeTasks(tasks).trim(), "ps {1, 2, 3} worker {4, 5, 6}");
+    assertEquals(TonyClient.mergeTasks(tasks).trim(), "ps [1, 2, 3] worker [4, 5, 6]");
   }
 
   @Test
   public void testMergeTasksSingleElement() {
     List<TaskInfo> tasks = new ArrayList<>();
     tasks.add(new TaskInfo("ps", "1", "url"));
-    assertEquals(TonyClient.mergeTasks(tasks).trim(), "ps {1}");
+    assertEquals(TonyClient.mergeTasks(tasks).trim(), "ps [1]");
 
     tasks.add(new TaskInfo("worker", "1", "url"));
-    assertEquals(TonyClient.mergeTasks(tasks).trim(), "ps {1} worker {1}");
+    assertEquals(TonyClient.mergeTasks(tasks).trim(), "ps [1] worker [1]");
   }
 }


### PR DESCRIPTION
This PR contains following changes
- Sort updated tasks based on status, name, and index. 
- Display all tasks' status when application is progressing so that users can check which task is running. 
- When the application is progressing, task status is being printed out in a simplified way where no URL is included for cleanness.
- Display all tasks' status along with their URL when application finishes.

The new log layout looks like following:
```
25-03-2021 19:49:07 PDT mnist-avro-distributed INFO - 2021-03-26 02:49:07 INFO  TonyClient:961 - ------  Application (re)starts, status of ALL tasks ------
25-03-2021 19:49:07 PDT mnist-avro-distributed INFO - 2021-03-26 02:49:07 INFO  TonyClient:1036 - RUNNING, chief, 0, some url
25-03-2021 19:49:07 PDT mnist-avro-distributed INFO - 2021-03-26 02:49:07 INFO  TonyClient:1036 - RUNNING, ps, 0, some url
25-03-2021 19:49:07 PDT mnist-avro-distributed INFO - 2021-03-26 02:49:07 INFO  TonyClient:1036 - RUNNING, worker, 0, some url
25-03-2021 19:49:07 PDT mnist-avro-distributed INFO - 2021-03-26 02:49:07 INFO  TonyClient:1036 - RUNNING, worker, 1, some url
25-03-2021 19:49:34 PDT mnist-avro-distributed INFO - 2021-03-26 02:49:34 INFO  TonyClient:968 - ------ Task Status Updated ------
25-03-2021 19:49:34 PDT mnist-avro-distributed INFO - 2021-03-26 02:49:34 INFO  TonyClient:1086 - FAILED: chief [0] ps [0] 
25-03-2021 19:49:34 PDT mnist-avro-distributed INFO - 2021-03-26 02:49:34 INFO  TonyClient:1086 - RUNNING: worker [0, 1] 
25-03-2021 19:49:35 PDT mnist-avro-distributed INFO - 2021-03-26 02:49:35 INFO  TonyClient:968 - ------ Task Status Updated ------
25-03-2021 19:49:35 PDT mnist-avro-distributed INFO - 2021-03-26 02:49:35 INFO  TonyClient:1086 - FAILED: chief [0] ps [0] 
25-03-2021 19:49:35 PDT mnist-avro-distributed INFO - 2021-03-26 02:49:35 INFO  TonyClient:1086 - FINISHED: worker [0, 1] 
25-03-2021 19:49:36 PDT mnist-avro-distributed INFO - 2021-03-26 02:49:36 INFO  TonyClient:984 - -----  Application finished, status of ALL tasks -----
25-03-2021 19:49:36 PDT mnist-avro-distributed INFO - 2021-03-26 02:49:36 INFO  TonyClient:1036 - FAILED, chief, 0, some url
25-03-2021 19:49:36 PDT mnist-avro-distributed INFO - 2021-03-26 02:49:36 INFO  TonyClient:1036 - FAILED, ps, 0, some url
25-03-2021 19:49:36 PDT mnist-avro-distributed INFO - 2021-03-26 02:49:36 INFO  TonyClient:1036 - FINISHED, worker, 0, some url
25-03-2021 19:49:36 PDT mnist-avro-distributed INFO - 2021-03-26 02:49:36 INFO  TonyClient:1036 - FINISHED, worker, 1, some url
```