### PR TITLE
Could not create cudnn handle: CUDNN_STATUS_INTERNAL_ERROR

### DIFF
--- a/tony-examples/mnist-tensorflow/mnist_keras_distributed.py
+++ b/tony-examples/mnist-tensorflow/mnist_keras_distributed.py
@@ -79,4 +79,10 @@ def train_mnist():
 
 
 if __name__ == '__main__':
+    physical_devices = tf.config.list_physical_devices('GPU')
+    try:
+        tf.config.experimental.set_memory_growth(physical_devices[0], True)
+    except:
+        # Invalid device or cannot modify virtual devices once initialized.
+        pass
     train_mnist()


### PR DESCRIPTION
When I'm running on TF 2.3.1 with the GPU, I am encountering
`2020-11-25 09:06:12.391615: E tensorflow/stream_executor/cuda/cuda_dnn.cc:328] Could not create cudnn handle: CUDNN_STATUS_INTERNAL_ERROR`

According to [this issue](https://github.com/tensorflow/tensorflow/issues/24496) the solution is to turn on [memory growth](https://www.tensorflow.org/guide/gpu?hl=en#limiting_gpu_memory_growth).

This PR has been tested on Hadoop 3.1 with TF 2.3.1 and Cuda 10.2 on Nvidia Tesla T4 


