### PR TITLE
Add more logging in TonY client and related utils to see if TonY config can be overridden by other parallel jobs.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ ext.deps = [
 
 allprojects {
   group = "com.linkedin.tony"
-  project.version = "0.4.1"
+  project.version = "0.4.2"
 }
 
 task sourcesJar(type: Jar) {

--- a/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
@@ -221,6 +221,7 @@ public class TonyClient implements AutoCloseable {
     // Write user's overridden conf to an xml to be localized.
     try (OutputStream os = new FileOutputStream(tonyFinalConf)) {
       tonyConf.writeXml(os);
+      LOG.info("TonY conf " + tonyFinalConf + " is created locally.");
     } catch (IOException exception) {
       LOG.error("Failed to write tony final conf to: " + tonyFinalConf, exception);
     }
@@ -742,6 +743,7 @@ public class TonyClient implements AutoCloseable {
     Path src = new Path(srcPath);
     Path dst = new Path(appResourcesPath, dstPath);
     HdfsUtils.copySrcToDest(src, dst, hdfsConf);
+    LOG.info(src + " is copied to HDFS location " + dst + ".");
     fs.setPermission(dst, new FsPermission((short) 0770));
     FileStatus scFileStatus = fs.getFileStatus(dst);
     LocalResource scRsrc =

--- a/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
+++ b/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
@@ -646,6 +646,7 @@ public class Utils {
                                                    LocalResourceType resourceType, String resourceKey) throws IOException {
     Path dst = new Path(hdfsPath, fileName);
     HdfsUtils.copySrcToDest(filePath, dst, tonyConf);
+    LOG.info(filePath + " is copied to HDFS location " + dst + ".");
     fs.setPermission(dst, new FsPermission((short) 0770));
     String dstAddress = dst.toString();
     if (resourceType == LocalResourceType.ARCHIVE) {


### PR DESCRIPTION
We already have a PR(https://github.com/linkedin/TonY/pull/455) to address the issue where concurrent TonY jobs could override each other's local TonY config. However we are seeing  TonY job config is conflicting again. This PR adds more logging to help debugging this issue.