### PR TITLE
Uuidify the name of local directory generated by TonY client

### DIFF
--- a/tony-azkaban/src/main/java/com/linkedin/tony/azkaban/TonyJob.java
+++ b/tony-azkaban/src/main/java/com/linkedin/tony/azkaban/TonyJob.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.log4j.Logger;
 
@@ -38,7 +39,8 @@ public class TonyJob extends HadoopJavaJob {
   public TonyJob(String jobid, Props sysProps, Props jobProps, Logger log) {
     super(jobid, sysProps, jobProps, log);
 
-    tonyXml = String.format("_tony-conf-%s/tony.xml", jobid);
+    UUID uuid = UUID.randomUUID();
+    tonyXml = String.format("_tony-conf-%s-%s/tony.xml", jobid, uuid);
     tonyConfFile = new File(getWorkingDirectory(), tonyXml);
     tonyConf = getJobConfiguration();
   }

--- a/tony-azkaban/src/test/java/com/linkedin/tony/azkaban/TestTonyJob.java
+++ b/tony-azkaban/src/test/java/com/linkedin/tony/azkaban/TestTonyJob.java
@@ -121,12 +121,17 @@ public class TestTonyJob {
     };
     List<String> paths = tonyJob.getClassPaths();
     int counter = 0;
+    String tonyConfigPath = new File(tonyJob.getWorkingDirectory(), "_tony-conf"
+        + "-test_tony_job_class_path").toString();
+    boolean hasTonYConfigInClassPath = false;
     for (String path : paths) {
       if (path.contains("Plugins/123") || path.contains("Plugins/456") || path.contains("Plugins/789")) {
         counter += 1;
+      } else if (path.startsWith(tonyConfigPath)) {
+        hasTonYConfigInClassPath = true;
       }
     }
     Assert.assertTrue(counter == 3);
-    Assert.assertTrue(paths.contains(new File(tonyJob.getWorkingDirectory(), "_tony-conf-test_tony_job_class_path").toString()));
+    Assert.assertTrue(hasTonYConfigInClassPath);
   }
 }


### PR DESCRIPTION
This PR is to address the directory naming conflict caused by different jobs of same job ID but within different sub-flows running in parallel.

E.g, the following 3 model training jobs which have the same name could override each other's TonY xml directory if without the fix. 
![image](https://user-images.githubusercontent.com/1428327/101980044-48e7d780-3c17-11eb-8c1a-b3cdc0d2404f.png)

