### PR TITLE
Proceed without failing if container resource paths do not exist

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
@@ -596,9 +596,11 @@ public class TonyClient implements AutoCloseable {
       }
       // Filter out original local file locations
       resources = tonyConf.getStrings(resourceKey);
+      LOG.info("A: " + Arrays.toString(resources));
       resources = Stream.of(resources).filter((filePath) ->
               new Path(filePath).toUri().getScheme() != null
       ).toArray(String[]::new);
+      LOG.info("B: " + Arrays.toString(resources));
       tonyConf.setStrings(resourceKey, resources);
     }
 

--- a/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
@@ -599,7 +599,7 @@ public class TonyClient implements AutoCloseable {
       // Filter out original local file locations
       resources = tonyConf.getStrings(resourceKey);
       resources = Stream.of(resources).filter((filePath) ->
-              new Path(filePath).toUri().getScheme() != null || !resourcesToBeRemoved.contains(filePath)
+              new Path(filePath).toUri().getScheme() != null && !resourcesToBeRemoved.contains(filePath)
       ).toArray(String[]::new);
       tonyConf.setStrings(resourceKey, resources);
     }

--- a/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
@@ -394,16 +394,19 @@ public class TonyClient implements AutoCloseable {
 
     // Set hdfsClassPath for all workers
     // Prepend hdfs:// if missing
-    String[] allHdfsClasspaths = cliParser.getOptionValue("hdfs_classpath").split(",");
-    for (int i = 0; i < allHdfsClasspaths.length; i++) {
-      String validPath = allHdfsClasspaths[i];
-      if (validPath != null && !validPath.startsWith(FileSystem.get(hdfsConf).getScheme())) {
-        validPath = FileSystem.getDefaultUri(hdfsConf) + validPath;
+    String allHdfsClasspathsString = cliParser.getOptionValue("hdfs_classpath");
+    if (allHdfsClasspathsString != null) {
+      String[] allHdfsClasspaths = allHdfsClasspathsString.split(",");
+      for (int i = 0; i < allHdfsClasspaths.length; i++) {
+        String validPath = allHdfsClasspaths[i];
+        if (validPath != null && !validPath.startsWith(FileSystem.get(hdfsConf).getScheme())) {
+          validPath = FileSystem.getDefaultUri(hdfsConf) + validPath;
+        }
+        Utils.appendConfResources(TonyConfigurationKeys.getContainerResourcesKey(), validPath, tonyConf);
+        allHdfsClasspaths[i] = validPath;
       }
-      Utils.appendConfResources(TonyConfigurationKeys.getContainerResourcesKey(), validPath, tonyConf);
-      allHdfsClasspaths[i] = validPath;
+      hdfsClasspath = String.join(",", allHdfsClasspaths);
     }
-    hdfsClasspath = String.join(",", allHdfsClasspaths);
 
     if (amMemory < 0) {
       throw new IllegalArgumentException("Invalid memory specified for application master, exiting."

--- a/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
@@ -394,11 +394,16 @@ public class TonyClient implements AutoCloseable {
 
     // Set hdfsClassPath for all workers
     // Prepend hdfs:// if missing
-    hdfsClasspath = cliParser.getOptionValue("hdfs_classpath");
-    if (hdfsClasspath != null && !hdfsClasspath.startsWith(FileSystem.get(hdfsConf).getScheme())) {
-      hdfsClasspath = FileSystem.getDefaultUri(hdfsConf) + hdfsClasspath;
+    String[] allHdfsClasspaths = cliParser.getOptionValue("hdfs_classpath").split(",");
+    for (int i = 0; i < allHdfsClasspaths.length; i++) {
+      String validPath = allHdfsClasspaths[i];
+      if (validPath != null && !validPath.startsWith(FileSystem.get(hdfsConf).getScheme())) {
+        validPath = FileSystem.getDefaultUri(hdfsConf) + validPath;
+      }
+      Utils.appendConfResources(TonyConfigurationKeys.getContainerResourcesKey(), validPath, tonyConf);
+      allHdfsClasspaths[i] = validPath;
     }
-    Utils.appendConfResources(TonyConfigurationKeys.getContainerResourcesKey(), hdfsClasspath, tonyConf);
+    hdfsClasspath = String.join(",", allHdfsClasspaths);
 
     if (amMemory < 0) {
       throw new IllegalArgumentException("Invalid memory specified for application master, exiting."

--- a/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
@@ -532,6 +532,7 @@ public class TonyClient implements AutoCloseable {
       if (resources == null) {
         continue;
       }
+      Set<String> resourcesToBeRemoved = new HashSet<>();
       for (String resource: resources) {
         // If a hdfs classpath does not exist, we skip it rather than failing the job.
         // This is because there are some cases where while constructing a ML flow, we have a hdfs classpath that might
@@ -543,6 +544,7 @@ public class TonyClient implements AutoCloseable {
         } catch (FileNotFoundException ex) {
           if (hdfsClasspath.contains(resource)) {
             LOG.warn("HDFS classpath does not exist for: " + resource);
+            resourcesToBeRemoved.add(resource);
             continue;
           } else {
             throw ex;
@@ -596,11 +598,9 @@ public class TonyClient implements AutoCloseable {
       }
       // Filter out original local file locations
       resources = tonyConf.getStrings(resourceKey);
-      LOG.info("A: " + Arrays.toString(resources));
       resources = Stream.of(resources).filter((filePath) ->
-              new Path(filePath).toUri().getScheme() != null
+              new Path(filePath).toUri().getScheme() != null || !resourcesToBeRemoved.contains(filePath)
       ).toArray(String[]::new);
-      LOG.info("B: " + Arrays.toString(resources));
       tonyConf.setStrings(resourceKey, resources);
     }
 

--- a/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
@@ -532,7 +532,14 @@ public class TonyClient implements AutoCloseable {
         continue;
       }
       for (String resource: resources) {
-        LocalizableResource lr = new LocalizableResource(resource, fs);
+        LocalizableResource lr;
+        // If a path does not exist, skip rather than failing.
+        try {
+          lr = new LocalizableResource(resource, fs);
+        } catch (IOException ex) {
+          LOG.info("Resource path does not exist for: " + resource);
+          continue;
+        }
         // If it is local file, we upload to remote fs first
         if (lr.isLocalFile()) {
           Path localFilePath = lr.getSourceFilePath();

--- a/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
@@ -533,12 +533,16 @@ public class TonyClient implements AutoCloseable {
       }
       for (String resource: resources) {
         LocalizableResource lr;
-        // If a path does not exist, skip rather than failing.
+        // If a path does not exist, skip rather than failing only for hdfs classpaths.
         try {
           lr = new LocalizableResource(resource, fs);
         } catch (IOException ex) {
           LOG.info("Resource path does not exist for: " + resource);
-          continue;
+          if (hdfsClasspath.contains(resource)) {
+            continue;
+          } else {
+            throw ex;
+          }
         }
         // If it is local file, we upload to remote fs first
         if (lr.isLocalFile()) {

--- a/tony-core/src/test/java/com/linkedin/tony/TestTonyE2E.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestTonyE2E.java
@@ -491,7 +491,7 @@ public class TestTonyE2E  {
   public void testTonyFinalConfWithNonExistentHDFSClasspath() throws IOException, YarnException, ParseException,
                                          InterruptedException, URISyntaxException {
     TonyClient client = spy(this.client);
-    String missingClasspath = "random/path";
+    String missingClasspath = cluster.getHdfsConf().get(CommonConfigurationKeys.FS_DEFAULT_NAME_KEY) + "/random/path";
     client.init(new String[]{
         "--executes", "ls",
         "--hdfs_classpath", missingClasspath + "," + libPath,

--- a/tony-core/src/test/java/com/linkedin/tony/TestTonyE2E.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestTonyE2E.java
@@ -491,7 +491,7 @@ public class TestTonyE2E  {
   public void testTonyFinalConfWithNonExistentHDFSClasspath() throws IOException, YarnException, ParseException,
                                          InterruptedException, URISyntaxException {
     TonyClient client = spy(this.client);
-    String missingClasspath = cluster.getHdfsConf().get(CommonConfigurationKeys.FS_DEFAULT_NAME_KEY) + "/random/path";
+    String missingClasspath = "random/path";
     client.init(new String[]{
         "--executes", "ls",
         "--hdfs_classpath", missingClasspath + "," + libPath,


### PR DESCRIPTION
If container resource paths do not exist, we want to be able to still continue looking at the resource paths that were available.