### PR TITLE
Pass dataset info from Azkaban to user code running in Tony job

### DIFF
--- a/tony-azkaban/src/main/java/com/linkedin/tony/azkaban/TonyJob.java
+++ b/tony-azkaban/src/main/java/com/linkedin/tony/azkaban/TonyJob.java
@@ -25,6 +25,12 @@ import org.apache.log4j.Logger;
  * env and jvm properties.
  */
 public class TonyJob extends HadoopJavaJob {
+  public static final String AZKABAN_INPUT_DATASET_JOB_PROP = "azkaban.input.dataset";
+  public static final String AZKABAN_INPUT_DATASET_ENV_VAR_KEY = "AZKABAN_INPUT_DATASET";
+  public static final String AZKABAN_OUTPUT_DATASET_JOB_PROP = "azkaban.output.dataset";
+  public static final String AZKABAN_OUTPUT_DATASET_ENV_VAR_KEY = "AZKABAN_OUTPUT_DATASET";
+  public static final String AZKABAN_ORIG_DELIMITER = ",";
+  public static final String AZKABAN_NEW_DELIMITER = ";";
   public static final String AZKABAN_WEB_HOST = "azkaban.webserverhost";
   public static final String HADOOP_OPTS = ENV_PREFIX + "HADOOP_OPTS";
   public static final String HADOOP_GLOBAL_OPTS = "hadoop.global.opts";
@@ -163,6 +169,22 @@ public class TonyJob extends HadoopJavaJob {
     String executes = getJobProps().getString(TonyJobArg.EXECUTES.azPropName, null);
     if (executes != null) {
       args.append(" " + TonyJobArg.EXECUTES.tonyParamName + " " + executes);
+    }
+
+    String azkabanInputDataset = getJobProps().getString(AZKABAN_INPUT_DATASET_JOB_PROP, null);
+    if (azkabanInputDataset != null) {
+      String inputWithNewDelimiter = azkabanInputDataset.replace(AZKABAN_ORIG_DELIMITER,
+          AZKABAN_NEW_DELIMITER);
+      args.append(" " + TonyJobArg.SHELL_ENV.tonyParamName + " " + AZKABAN_INPUT_DATASET_ENV_VAR_KEY
+          + "='" + inputWithNewDelimiter + "'");
+    }
+
+    String azkabanOutputDataset = getJobProps().getString(AZKABAN_OUTPUT_DATASET_JOB_PROP, null);
+    if (azkabanOutputDataset != null) {
+      String outputWithNewDelimiter = azkabanOutputDataset.replace(AZKABAN_ORIG_DELIMITER,
+          AZKABAN_NEW_DELIMITER);
+      args.append(" " + TonyJobArg.SHELL_ENV.tonyParamName + " " + AZKABAN_OUTPUT_DATASET_ENV_VAR_KEY
+          + "='" + outputWithNewDelimiter + "'");
     }
 
     info("Complete main arguments: " + args);

--- a/tony-azkaban/src/test/java/com/linkedin/tony/azkaban/TestTonyJob.java
+++ b/tony-azkaban/src/test/java/com/linkedin/tony/azkaban/TestTonyJob.java
@@ -52,8 +52,15 @@ public class TestTonyJob {
 
   @Test
   public void testMainArguments() {
+    final String azkabanInputDataset = "AZKABAN_INPUT_DATASET";
+    final String azkabanOutputDataset = "AZKABAN_OUTPUT_DATASET";
+
     final Props jobProps = new Props();
     jobProps.put(TonyJobArg.HDFS_CLASSPATH.azPropName, "hdfs://nn:8020");
+    jobProps.put(TonyJob.WORKER_ENV_PREFIX + azkabanInputDataset,
+        "HDFS_DYNAMIC_PATH:input_ds:/jobs/azktest/gsalia_tony/192/input_ds_job1");
+    jobProps.put(TonyJob.WORKER_ENV_PREFIX + azkabanOutputDataset,
+        "HDFS_DYNAMIC_PATH:output_ds:/jobs/azktest/gsalia_tony/192/output_ds_job1");
     jobProps.put(TonyJob.WORKER_ENV_PREFIX + "E1", "e1");
     jobProps.put(TonyJob.WORKER_ENV_PREFIX + "E2", "e2");
 
@@ -65,6 +72,10 @@ public class TestTonyJob {
     };
     String args = tonyJob.getMainArguments();
     Assert.assertTrue(args.contains(TonyJobArg.HDFS_CLASSPATH.tonyParamName + " hdfs://nn:8020"));
+    Assert.assertTrue(args.contains(TonyJobArg.SHELL_ENV.tonyParamName + " " + azkabanInputDataset
+        + "=HDFS_DYNAMIC_PATH:input_ds:/jobs/azktest/gsalia_tony/192/input_ds_job1"));
+    Assert.assertTrue(args.contains(TonyJobArg.SHELL_ENV.tonyParamName + " " + azkabanOutputDataset
+        + "=HDFS_DYNAMIC_PATH:output_ds:/jobs/azktest/gsalia_tony/192/output_ds_job1"));
     Assert.assertTrue(args.contains(TonyJobArg.SHELL_ENV.tonyParamName + " E2=e2"));
     Assert.assertTrue(args.contains(TonyJobArg.SHELL_ENV.tonyParamName + " E1=e1"));
   }

--- a/tony-azkaban/src/test/java/com/linkedin/tony/azkaban/TestTonyJob.java
+++ b/tony-azkaban/src/test/java/com/linkedin/tony/azkaban/TestTonyJob.java
@@ -52,14 +52,16 @@ public class TestTonyJob {
 
   @Test
   public void testMainArguments() {
-    final String azkabanInputDataset = "AZKABAN_INPUT_DATASET";
-    final String azkabanOutputDataset = "AZKABAN_OUTPUT_DATASET";
+    final String azkabanInputDatasetJobProp = "azkaban.input.dataset";
+    final String azkabanOutputDatasetJobProp = "azkaban.output.dataset";
+    final String azkabanInputDatasetEnvVarKey = "AZKABAN_INPUT_DATASET";
+    final String azkabanOutputDatasetEnvVarKey = "AZKABAN_OUTPUT_DATASET";
 
     final Props jobProps = new Props();
     jobProps.put(TonyJobArg.HDFS_CLASSPATH.azPropName, "hdfs://nn:8020");
-    jobProps.put(TonyJob.WORKER_ENV_PREFIX + azkabanInputDataset,
+    jobProps.put(azkabanInputDatasetJobProp,
         "HDFS_DYNAMIC_PATH:input_ds:/jobs/azktest/gsalia_tony/192/input_ds_job1");
-    jobProps.put(TonyJob.WORKER_ENV_PREFIX + azkabanOutputDataset,
+    jobProps.put(azkabanOutputDatasetJobProp,
         "HDFS_DYNAMIC_PATH:output_ds:/jobs/azktest/gsalia_tony/192/output_ds_job1");
     jobProps.put(TonyJob.WORKER_ENV_PREFIX + "E1", "e1");
     jobProps.put(TonyJob.WORKER_ENV_PREFIX + "E2", "e2");
@@ -72,10 +74,12 @@ public class TestTonyJob {
     };
     String args = tonyJob.getMainArguments();
     Assert.assertTrue(args.contains(TonyJobArg.HDFS_CLASSPATH.tonyParamName + " hdfs://nn:8020"));
-    Assert.assertTrue(args.contains(TonyJobArg.SHELL_ENV.tonyParamName + " " + azkabanInputDataset
-        + "=HDFS_DYNAMIC_PATH:input_ds:/jobs/azktest/gsalia_tony/192/input_ds_job1"));
-    Assert.assertTrue(args.contains(TonyJobArg.SHELL_ENV.tonyParamName + " " + azkabanOutputDataset
-        + "=HDFS_DYNAMIC_PATH:output_ds:/jobs/azktest/gsalia_tony/192/output_ds_job1"));
+    Assert.assertTrue(args.contains(TonyJobArg.SHELL_ENV.tonyParamName
+        + " " + azkabanInputDatasetEnvVarKey
+        + "='HDFS_DYNAMIC_PATH:input_ds:/jobs/azktest/gsalia_tony/192/input_ds_job1'"));
+    Assert.assertTrue(args.contains(TonyJobArg.SHELL_ENV.tonyParamName
+        + " " + azkabanOutputDatasetEnvVarKey
+        + "='HDFS_DYNAMIC_PATH:output_ds:/jobs/azktest/gsalia_tony/192/output_ds_job1'"));
     Assert.assertTrue(args.contains(TonyJobArg.SHELL_ENV.tonyParamName + " E2=e2"));
     Assert.assertTrue(args.contains(TonyJobArg.SHELL_ENV.tonyParamName + " E1=e1"));
   }


### PR DESCRIPTION
Azkaban lets users specify dataset information for a job and dataset
based dependencies between jobs in the DSL. The dataset information
needs to be passed from Azkaban all the way to the user code that is
run inside Tony job.