### PR TITLE
Catch exception on getting HDFS delegation token, like standby namenode exception

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/security/TokenCache.java
+++ b/tony-core/src/main/java/com/linkedin/tony/security/TokenCache.java
@@ -47,7 +47,11 @@ public class TokenCache {
       fsSet.add(path.getFileSystem(conf));
     }
     for (FileSystem fs : fsSet) {
-      obtainTokensForNamenodesInternal(fs, credentials, renewer);
+      try {
+        obtainTokensForNamenodesInternal(fs, credentials, renewer);
+      } catch (Exception e) {
+        LOG.error("Errors on getting delegation token for " + fs.getUri(), e);
+      }
     }
   }
 


### PR DESCRIPTION
### Why
When a non-active namneode is set in the **tony.other.namenode** configuration, an exception will be thrown.
I think we should catch it.