### PR TITLE
[MINOR] Support specify timeout for AM waiting for client signal stop

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/ApplicationMaster.java
+++ b/tony-core/src/main/java/com/linkedin/tony/ApplicationMaster.java
@@ -187,6 +187,9 @@ public class ApplicationMaster {
   /** Container registration timeout time **/
   private long registrationTimeoutMs;
 
+  /** AM waiting timeout of client signal stop **/
+  private int waitingClientSignalStopTimeout;
+
   private ApplicationMaster() {
     hdfsConf = new Configuration(false);
     yarnConf = new Configuration(false);
@@ -272,6 +275,9 @@ public class ApplicationMaster {
     distributedMode = TonyConfigurationKeys.DistributedMode.valueOf(distributedModeVal.toUpperCase());
     registrationTimeoutMs = tonyConf.getInt(TonyConfigurationKeys.CONTAINER_ALLOCATION_TIMEOUT,
             TonyConfigurationKeys.DEFAULT_CONTAINER_ALLOCATION_TIMEOUT);
+
+    waitingClientSignalStopTimeout = tonyConf.getInt(TonyConfigurationKeys.AM_WAIT_CLIENT_STOP_TIMEOUT,
+                                                  TonyConfigurationKeys.DEFAULT_AM_WAIT_CLIENT_STOP_TIMEOUT);
 
     // Set an environment variable to pass the appid
     containerEnv.put(Constants.APPID, appIdString);
@@ -705,7 +711,7 @@ public class ApplicationMaster {
     nmClientAsync.stop();
     amRMClient.stop();
     // Poll until TonyClient signals we should exit
-    boolean result = Utils.poll(() -> clientSignalToStop, 1, 15);
+    boolean result = Utils.poll(() -> clientSignalToStop, 1, waitingClientSignalStopTimeout);
     if (!result) {
       LOG.warn("TonyClient didn't signal Tony AM to stop.");
     }

--- a/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
@@ -179,6 +179,9 @@ public class TonyConfigurationKeys {
   public static final String AM_GPUS = AM_PREFIX + "gpus";
   public static final int DEFAULT_AM_GPUS = 0;
 
+  public static final String AM_WAIT_CLIENT_STOP_TIMEOUT = AM_PREFIX + "wait-client-signal-stop-timeout-sec";
+  public static final int DEFAULT_AM_WAIT_CLIENT_STOP_TIMEOUT = 15;
+
   // Keys/default values for configurable TensorFlow job names
   public static final String INSTANCES_REGEX = "tony\\.([a-z]+)\\.instances";
   public static final String MAX_TOTAL_RESOURCES_REGEX = TONY_TASK_PREFIX + "max-total-([a-z]+)";

--- a/tony-core/src/main/resources/tony-default.xml
+++ b/tony-core/src/main/resources/tony-default.xml
@@ -150,6 +150,12 @@
     <value>0</value>
   </property>
 
+  <property>
+    <description>Timeout, in seconds for AM waiting client stop signal before AM finish.</description>
+    <name>tony.am.wait-client-signal-stop-timeout-sec</name>
+    <value>15</value>
+  </property>
+
   <!-- PS configurations -->
   <property>
     <description>Parameter server memory size, requested as a string (e.g. '2g' or '2048m').</description>


### PR DESCRIPTION
### Why
In once loop of `monitorApplication` method, when costing too much time over 15s , AM will finished, not waiting TonY client stop signal.
So AM rpc service will closed. But TonY client will call updateTaskInfos method, it will cause exception.

I think it's necessary to allow specify AM waiting timeout, because we extend the ClusterSubmmitter to support `TaskUpdateListener`, which may cost too much time in `monitorApplication` once loop.