### PR TITLE
TonYClient ignore connection error to prevent app failure when sending AM stop signal

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyClient.java
@@ -1004,15 +1004,21 @@ public class TonyClient implements AutoCloseable {
       }
     }
 
-    if (amRpcClient != null) {
-      amRpcClient.finishApplication();
-      LOG.info("Sent message to AM to stop.");
-      amRpcClient = null;
-    }
-
+    signalAMToFinish();
     return result;
   }
 
+  private void signalAMToFinish() {
+    if (amRpcClient != null) {
+      LOG.info("Sending message to AM to stop.");
+      try {
+        amRpcClient.finishApplication();
+      } catch (Exception e) {
+        LOG.error("Errors on calling AM to finish application. Maybe AM has finished.", e);
+      }
+      amRpcClient = null;
+    }
+  }
 
   /**
    * Logs task info. Task info will be sorted by status, then name, then index in the log.
@@ -1103,7 +1109,7 @@ public class TonyClient implements AutoCloseable {
           taskInfos = receivedInfos;
         }
       } catch (IOException | YarnException e) {
-        LOG.error("Errors on calling AM to update task infos.");
+        LOG.error("Errors on calling AM to update task infos.", e);
       }
     }
     return taskUpdated;


### PR DESCRIPTION
### Why
Same as this [PR](https://github.com/linkedin/TonY/pull/517)

> As we know, TonY client will get AM status from RM in monitorApplication. But when encountering connection error on exec updateTaskInfos method, it will throw exception and client will finished and exit none-zero code. Actually, AM finished successfully.

> This will cause our workflow system to misjudge the task status. We should only rely on RM's status recognition of the application.


In this PR, client will also send stop signal to AM. But when AM has finished, this call will throw exception.
I think we should ignore its exception.