### PR TITLE
Allow to specify side-car job type for task to ignore its failure

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/ApplicationMaster.java
+++ b/tony-core/src/main/java/com/linkedin/tony/ApplicationMaster.java
@@ -1241,6 +1241,7 @@ public class ApplicationMaster {
 
       LOG.info("Container " + containerId + " for task " + task + " finished with exitStatus " + exitStatus + ".");
       session.onTaskCompleted(task.getJobName(), task.getTaskIndex(), exitStatus, diagnosticMessage);
+
       scheduler.registerDependencyCompleted(task.getJobName());
       if (ContainerExitStatus.SUCCESS != exitStatus) {
         eventHandler.emitEvent(new Event(EventType.TASK_FINISHED,
@@ -1257,7 +1258,8 @@ public class ApplicationMaster {
       }
 
       // Detect if an untracked task has crashed to prevent application hangups.
-      if (!Utils.isJobTypeTracked(task.getJobName(), tonyConf) && task.isFailed()) {
+      boolean fastFail = Utils.isUntrackedJobType(task.getJobName(), tonyConf) && task.isFailed();
+      if (fastFail) {
         untrackedTaskFailed = true;
       }
 
@@ -1269,6 +1271,15 @@ public class ApplicationMaster {
   private boolean startupFailed() {
     Set<TonyTask> completedFailedTasks = getCompletedFailedTasks();
     LOG.debug("Completed failed task size: " + completedFailedTasks.size());
+    LOG.info("Completed failed tasks list:");
+    completedFailedTasks.stream().forEach(x -> {
+      LOG.info("Jobname: " + x.getJobName() + ", index: " + x.getTaskIndex());
+    });
+
+    LOG.info("Registered tasks list:");
+    session.getRegisteredTasks().stream().forEach(x -> {
+      LOG.info(x);
+    });
 
     // When executor failed and not registering to AM, it means task failed when starting task executor process
     return completedFailedTasks.stream().anyMatch(t -> {

--- a/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
@@ -270,6 +270,10 @@ public class TonyConfigurationKeys {
   public static final String UNTRACKED_JOBTYPES = TONY_APPLICATION_PREFIX + "untracked.jobtypes";
   public static final String UNTRACKED_JOBTYPES_DEFAULT = "ps";
 
+  // Job types that we don't wait to finish and ignore its failure.
+  public static final String SIDECAR_JOBTYPES = TONY_APPLICATION_PREFIX + "sidecar.jobtypes";
+  public static final String DEFAULT_SIDECAR_JOBTYPES = SIDECAR_TENSORBOARD_ROLE_NAME;
+
   // Job types that we will short circuit when it failed
   public static final String STOP_ON_FAILURE_JOBTYPES = TONY_APPLICATION_PREFIX + "stop-on-failure-jobtypes";
 

--- a/tony-core/src/main/java/com/linkedin/tony/tensorflow/TonySession.java
+++ b/tony-core/src/main/java/com/linkedin/tony/tensorflow/TonySession.java
@@ -182,7 +182,7 @@ public class TonySession {
   }
 
   public int getTotalTrackedTasks() {
-    return jobTasks.entrySet().stream().filter(entry -> Utils.isJobTypeTracked(entry.getKey(), tonyConf))
+    return jobTasks.entrySet().stream().filter(entry -> Utils.isJobTypeMonitored(entry.getKey(), tonyConf))
         .mapToInt(entry -> entry.getValue().length).sum();
   }
 
@@ -192,7 +192,7 @@ public class TonySession {
   }
 
   public int getNumCompletedTrackedTasks() {
-    return (int) jobTasks.entrySet().stream().filter(entry -> Utils.isJobTypeTracked(entry.getKey(), tonyConf))
+    return (int) jobTasks.entrySet().stream().filter(entry -> Utils.isJobTypeMonitored(entry.getKey(), tonyConf))
         .flatMap(entry -> Arrays.stream(entry.getValue())).filter(task -> task != null && task.isCompleted()).count();
   }
 
@@ -302,7 +302,7 @@ public class TonySession {
       TonyTask[] tasks = entry.getValue();
 
       // If the job type is not tracked, continue.
-      if (!Utils.isJobTypeTracked(jobName, tonyConf)) {
+      if (!Utils.isJobTypeMonitored(jobName, tonyConf)) {
         continue;
       }
 

--- a/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
+++ b/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
@@ -669,8 +669,25 @@ public class Utils {
     return conf.getStrings(TonyConfigurationKeys.UNTRACKED_JOBTYPES, TonyConfigurationKeys.UNTRACKED_JOBTYPES_DEFAULT);
   }
 
-  public static boolean isJobTypeTracked(String taskName, Configuration tonyConf) {
-    return !Arrays.asList(getUntrackedJobTypes(tonyConf)).contains(taskName);
+  public static String[] getSidecarJobTypes(Configuration conf) {
+    return conf.getStrings(TonyConfigurationKeys.SIDECAR_JOBTYPES, TonyConfigurationKeys.SIDECAR_JOBTYPES);
+  }
+
+  public static boolean isSidecarJobType(String taskName, Configuration tonyConf) {
+    return Arrays.asList(getSidecarJobTypes(tonyConf)).contains(taskName);
+  }
+
+  // If task is not tracked and side-car, it will be monitored.
+  public static boolean isJobTypeMonitored(String taskName, Configuration tonyConf) {
+    List<String> untrackedJobTypes = new ArrayList<>();
+    untrackedJobTypes.addAll(Arrays.asList(getUntrackedJobTypes(tonyConf)));
+    untrackedJobTypes.addAll(Arrays.asList(getSidecarJobTypes(tonyConf)));
+    return !untrackedJobTypes.contains(taskName);
+  }
+
+  public static boolean isUntrackedJobType(String taskName, Configuration tonyConf) {
+    List<String> untrackedJobTypes = new ArrayList<>(Arrays.asList(getUntrackedJobTypes(tonyConf)));
+    return untrackedJobTypes.contains(taskName);
   }
 
   public static String[] getStopOnFailureJobTypes(Configuration conf) {

--- a/tony-core/src/main/resources/tony-default.xml
+++ b/tony-core/src/main/resources/tony-default.xml
@@ -208,6 +208,13 @@
     <value>ps</value>
   </property>
 
+  <!-- Sidecar job type configurations -->
+  <property>
+    <description>Job types that we don't track to finish and ignore its failure</description>
+    <name>tony.application.sidecar.jobtypes</name>
+    <value>tensorboard</value>
+  </property>
+
   <!-- Stop on failure job type configurations -->
   <property>
     <description>Job types that we will short circuit when it failed</description>

--- a/tony-core/src/test/java/com/linkedin/tony/util/TestUtils.java
+++ b/tony-core/src/test/java/com/linkedin/tony/util/TestUtils.java
@@ -314,7 +314,7 @@ public class TestUtils {
     conf.setInt("tony.evaluator.vcores", 2);
     conf.setInt("tony.chief.gpus", 1);
 
-    assertTrue(Utils.isJobTypeTracked("tony.worker.gpus", conf));
+    assertTrue(Utils.isJobTypeMonitored("tony.worker.gpus", conf));
   }
 
   @Test


### PR DESCRIPTION
It's necessary to Introduce side-car job type, which can ignore the failure of some jobs, like the job of built-in tensorboard.