### PR TITLE
Allow to specify sidecar tensorboard startup extra options

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
+++ b/tony-core/src/main/java/com/linkedin/tony/TonyConfigurationKeys.java
@@ -334,4 +334,6 @@ public class TonyConfigurationKeys {
 
   public static final String TB_GPUS = TB_JOB_PREFIX + "gpus";
   public static final int DEFAULT_TB_GPUS = 0;
+
+  public static final String TB_EXTRA_STARTUP_OPTIONS = TB_JOB_PREFIX + "startup-opts";
 }

--- a/tony-core/src/main/java/com/linkedin/tony/runtime/MLGenericRuntime.java
+++ b/tony-core/src/main/java/com/linkedin/tony/runtime/MLGenericRuntime.java
@@ -239,8 +239,10 @@ public abstract class MLGenericRuntime implements FrameworkRuntime {
         String tbLogDir = taskExecutor.getTonyConf().get(TonyConfigurationKeys.TENSORBOARD_LOG_DIR);
         Path tbScriptPath = createSidecarTBScript();
         String pythonExecPath = taskExecutor.getTonyConf().get(TonyConfigurationKeys.PYTHON_EXEC_PATH, "python");
-        String startTBCommand = String.format("%s %s --logdir %s --port %s",
-                pythonExecPath, tbScriptPath, tbLogDir, taskExecutor.getTbPort());
+        String startupExtraOpts = taskExecutor.getTonyConf().get(TonyConfigurationKeys.TB_EXTRA_STARTUP_OPTIONS, "");
+
+        String startTBCommand = String.format("%s %s --logdir %s --port %s %s",
+                pythonExecPath, tbScriptPath, tbLogDir, taskExecutor.getTbPort(), startupExtraOpts);
         log.info("Sidecar tensorboard startup command: " + startTBCommand);
         taskExecutor.setTaskCommand(startTBCommand);
 

--- a/tony-core/src/test/java/com/linkedin/tony/TestTonyConfigurationFields.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestTonyConfigurationFields.java
@@ -55,6 +55,7 @@ public class TestTonyConfigurationFields extends TestConfigurationFieldsBase {
     configurationPropsToSkipCompare.add(TonyConfigurationKeys.TB_MEMORY);
     configurationPropsToSkipCompare.add(TonyConfigurationKeys.TB_INSTANCES);
     configurationPropsToSkipCompare.add(TonyConfigurationKeys.TB_GPUS);
+    configurationPropsToSkipCompare.add(TonyConfigurationKeys.TB_EXTRA_STARTUP_OPTIONS);
   }
 
   @BeforeTest


### PR DESCRIPTION
Sometimes, we need to specify extra sidecar tb-startup params, like tensorboard `--reload-interval` or `--bind_all`