### PR TITLE
TonY should throw exception when gpu resource is not found on cluster

### DIFF
--- a/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
+++ b/tony-core/src/main/java/com/linkedin/tony/util/Utils.java
@@ -390,7 +390,7 @@ public class Utils {
       int gpus = conf.getInt(TonyConfigurationKeys.getResourceKey(jobName, Constants.GPUS),
               TonyConfigurationKeys.DEFAULT_GPUS);
       if (gpus > 0 && !ResourceUtils.getResourceTypeIndex().containsKey(Constants.GPU_URI)) {
-        LOG.warn(String.format("User requested %d GPUs for job '%s' but GPU is not available on the cluster. ",
+        throw new RuntimeException(String.format("User requested %d GPUs for job '%s' but GPU is not available on the cluster. ",
             gpus, jobName));
       }
 

--- a/tony-core/src/test/java/com/linkedin/tony/TestTonyClient.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestTonyClient.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Map;
 import org.apache.commons.cli.ParseException;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.util.hash.Hash;
 import org.apache.hadoop.yarn.api.records.ResourceInformation;
 import org.apache.hadoop.yarn.util.resource.ResourceUtils;
 import org.testng.annotations.Test;

--- a/tony-core/src/test/java/com/linkedin/tony/TestTonyClient.java
+++ b/tony-core/src/test/java/com/linkedin/tony/TestTonyClient.java
@@ -20,7 +20,6 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 
-import static com.linkedin.tony.Constants.*;
 import static org.testng.Assert.assertEquals;
 
 public class TestTonyClient {
@@ -123,7 +122,7 @@ public class TestTonyClient {
    * 1 GPU requested on a non-GPU cluster. Conf validation should fail.
    */
   @Test(expectedExceptions = RuntimeException.class,
-      expectedExceptionsMessageRegExp = "User requested 1 GPUs for job .* but GPU is not available on the cluster. " )
+      expectedExceptionsMessageRegExp = "User requested 1 GPUs for job .* but GPU is not available on the cluster. ")
   public void testValidateTonyConfNoGpuCluster() {
     Configuration conf = new Configuration();
     Map<String, ResourceInformation> resourceInformationMap = new HashMap<>();
@@ -213,7 +212,7 @@ public class TestTonyClient {
     Map<String, ResourceInformation> resourceInformationMap = new HashMap<>();
     resourceInformationMap.put("memory-mb", ResourceInformation.MEMORY_MB);
     resourceInformationMap.put("vcores", ResourceInformation.VCORES);
-    resourceInformationMap.put(GPU_URI, ResourceInformation.GPUS);
+    resourceInformationMap.put(Constants.GPU_URI, ResourceInformation.GPUS);
     ResourceUtils.initializeResourcesFromResourceInformationMap(resourceInformationMap);
   }
 }


### PR DESCRIPTION
When user request to run a GPU job on a cluster without GPU resources, we should throw a runtime error.